### PR TITLE
Courses, Unit of Work, In Memory Data Store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,17 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
+    'prefer-destructuring': 'off',
   },
+  overrides: [
+    {
+      files: ['*.test.js'],
+      rules: {
+        'no-plusplus': 'off',
+        'no-unused-expressions': 'off',
+        'no-unused-vars': 'off',
+        'no-undef': 'off',
+      }
+    }
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ application with basline functionality.</p>
 
 - Node/Express Project Setup (Complete)
 - Basic CRUD End Points (Complete)
-- Design data model 
-- Implement Database Abstraction Layer
-- Implement In-Memory Data Store
+- Design data model (Complete)
+- Implement Database Abstraction Layer (Complete)
+- Implement In-Memory Data Store (Complete)
 - Draw-up/Prototype UI
 - Build Out Basic React Front End UI 
 - Implement testing for each application layer (ideally this will be done in conjuction with implementing each layer)

--- a/controllers/courseController.js
+++ b/controllers/courseController.js
@@ -1,13 +1,13 @@
 const UnitOfWork = require('../data/UnitOfWork');
 
-const uow = new UnitOfWork();
+const unitOfwork = new UnitOfWork();
 
 const getAll = (req, res) => {
-  res.send(uow.courseRepo.getAll());
+  res.send(unitOfwork.courseRepo.getAll());
 };
 
 const getById = (req, res) => {
-  const course = uow.courseRepo.getById(parseInt(req.params.id, 10));
+  const course = unitOfwork.courseRepo.getById(parseInt(req.params.id, 10));
   if (course) {
     res.send(course);
   } else {
@@ -16,7 +16,7 @@ const getById = (req, res) => {
 };
 
 const create = (req, res) => {
-  res.json(uow.courseRepo.newCourse(req.body.title));
+  res.json(unitOfwork.courseRepo.newCourse(req.body.title));
 };
 
 const updateById = (req, res) => {
@@ -24,7 +24,7 @@ const updateById = (req, res) => {
     id: parseInt(req.params.id, 10),
     title: req.body.title,
   };
-  const course = uow.courseRepo.update(props);
+  const course = unitOfwork.courseRepo.update(props);
   if (course) {
     res.send(course);
   } else {
@@ -33,7 +33,7 @@ const updateById = (req, res) => {
 };
 
 const deleteById = (req, res) => {
-  const deletedCourse = uow.courseRepo.deleteById(parseInt(req.params.id, 10));
+  const deletedCourse = unitOfwork.courseRepo.deleteById(parseInt(req.params.id, 10));
   if (deletedCourse) {
     res.send(deletedCourse);
   } else {

--- a/controllers/courseController.js
+++ b/controllers/courseController.js
@@ -6,7 +6,7 @@ const getAll = (req, res) => {
   res.send(uow.courseRepo.getAll());
 };
 
-const getByID = (req, res) => {
+const getById = (req, res) => {
   const course = uow.courseRepo.getById(parseInt(req.params.id, 10));
   if (course) {
     res.send(course);
@@ -19,7 +19,7 @@ const create = (req, res) => {
   res.json(uow.courseRepo.newCourse(req.body.title));
 };
 
-const updateByID = (req, res) => {
+const updateById = (req, res) => {
   const props = {
     id: parseInt(req.params.id, 10),
     title: req.body.title,
@@ -32,8 +32,8 @@ const updateByID = (req, res) => {
   }
 };
 
-const deleteByID = (req, res) => {
-  const deletedCourse = uow.courseRepo.deleteByID(parseInt(req.params.id, 10));
+const deleteById = (req, res) => {
+  const deletedCourse = uow.courseRepo.deleteById(parseInt(req.params.id, 10));
   if (deletedCourse) {
     res.send(deletedCourse);
   } else {
@@ -43,8 +43,8 @@ const deleteByID = (req, res) => {
 
 module.exports = {
   getAll,
-  getByID,
+  getById,
   create,
-  updateByID,
-  deleteByID,
+  updateById,
+  deleteById,
 };

--- a/controllers/courseController.js
+++ b/controllers/courseController.js
@@ -1,0 +1,50 @@
+const UnitOfWork = require('../data/UnitOfWork');
+
+const uow = new UnitOfWork();
+
+const getAll = (req, res) => {
+  res.send(uow.courseRepo.getAll());
+};
+
+const getByID = (req, res) => {
+  const course = uow.courseRepo.getById(parseInt(req.params.id, 10));
+  if (course) {
+    res.send(course);
+  } else {
+    res.status(404).send('The course with the given id was not found.');
+  }
+};
+
+const create = (req, res) => {
+  res.json(uow.courseRepo.newCourse(req.body.title));
+};
+
+const updateByID = (req, res) => {
+  const props = {
+    id: parseInt(req.params.id, 10),
+    title: req.body.title,
+  };
+  const course = uow.courseRepo.update(props);
+  if (course) {
+    res.send(course);
+  } else {
+    res.status(404).send('The course with the given id was not found.');
+  }
+};
+
+const deleteByID = (req, res) => {
+  const deletedCourse = uow.courseRepo.deleteByID(parseInt(req.params.id, 10));
+  if (deletedCourse) {
+    res.send(deletedCourse);
+  } else {
+    res.status(404).send('The task with the given id was not found.');
+  }
+};
+
+module.exports = {
+  getAll,
+  getByID,
+  create,
+  updateByID,
+  deleteByID,
+};

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -17,7 +17,7 @@ const getAll = (req, res) => {
 };
 
 const getByID = (req, res) => {
-  const task = taskRepo.getByID(parseInt(req.params.id, 10));
+  const task = taskRepo.getById(parseInt(req.params.id, 10));
   if (task) {
     res.send(task);
   } else {

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -1,13 +1,13 @@
 const UnitOfWork = require('../data/UnitOfWork');
 
-const uow = new UnitOfWork();
+const unitOfWork = new UnitOfWork();
 
 const getAll = (req, res) => {
-  res.send(uow.taskRepo.getAll());
+  res.send(unitOfWork.taskRepo.getAll());
 };
 
 const getById = (req, res) => {
-  const task = uow.taskRepo.getById(parseInt(req.params.id, 10));
+  const task = unitOfWork.taskRepo.getById(parseInt(req.params.id, 10));
   if (task) {
     res.send(task);
   } else {
@@ -16,7 +16,7 @@ const getById = (req, res) => {
 };
 
 const create = (req, res) => {
-  res.json(uow.createTask(req.body.title, parseInt(req.body.courseId, 10)));
+  res.json(unitOfWork.createTask(req.body.title, parseInt(req.body.courseId, 10)));
 };
 
 const updateById = (req, res) => {
@@ -28,7 +28,7 @@ const updateById = (req, res) => {
     completed: req.body.completed,
     scheduledDate: req.body.scheduledDate,
   };
-  const task = uow.taskRepo.update(props);
+  const task = unitOfWork.taskRepo.update(props);
   if (task) {
     res.send(task);
   } else {
@@ -37,7 +37,7 @@ const updateById = (req, res) => {
 };
 
 const deleteById = (req, res) => {
-  const deletedTask = uow.taskRepo.deleteById(parseInt(req.params.id, 10));
+  const deletedTask = unitOfWork.taskRepo.deleteById(parseInt(req.params.id, 10));
   if (deletedTask) {
     res.send(deletedTask);
   } else {

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -1,14 +1,6 @@
-// eslint-disable-next-line prefer-destructuring
-// const argv = require('yargs').argv;
-// const seed = require('../dev/seed');
 const UnitOfWork = require('../data/UnitOfWork');
 
 const uow = new UnitOfWork();
-// will this ever be called twice?
-/* if (process.env.NODE_ENV === 'development' && argv.seed) {
-  console.log('seeding database...');
-  seed(uow.taskRepo, argv.seed);
-} */
 
 const getAll = (req, res) => {
   res.send(uow.taskRepo.getAll());

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -1,23 +1,21 @@
 // eslint-disable-next-line prefer-destructuring
-const argv = require('yargs').argv;
-const TaskRepository = require('../data/TaskRepository');
-const TaskMemoryDAO = require('../data/TaskMemoryDAO');
-const seed = require('../dev/seed');
+// const argv = require('yargs').argv;
+// const seed = require('../dev/seed');
+const UnitOfWork = require('../data/UnitOfWork');
 
-const taskRepo = new TaskRepository(new TaskMemoryDAO());
-
+const uow = new UnitOfWork();
 // will this ever be called twice?
-if (process.env.NODE_ENV === 'development' && argv.seed) {
+/* if (process.env.NODE_ENV === 'development' && argv.seed) {
   console.log('seeding database...');
-  seed(taskRepo, argv.seed);
-}
+  seed(uow.taskRepo, argv.seed);
+} */
 
 const getAll = (req, res) => {
-  res.send(taskRepo.getAll());
+  res.send(uow.taskRepo.getAll());
 };
 
 const getByID = (req, res) => {
-  const task = taskRepo.getById(parseInt(req.params.id, 10));
+  const task = uow.taskRepo.getById(parseInt(req.params.id, 10));
   if (task) {
     res.send(task);
   } else {
@@ -26,11 +24,7 @@ const getByID = (req, res) => {
 };
 
 const create = (req, res) => {
-  res.json(taskRepo.newTask({
-    title: req.body.title,
-    course: req.body.course,
-    deadline: req.body.deadline,
-  }));
+  res.json(uow.createTask(req.body.title, parseInt(req.body.courseId, 10)));
 };
 
 const updateByID = (req, res) => {
@@ -42,7 +36,7 @@ const updateByID = (req, res) => {
     completed: req.body.completed,
     scheduledDate: req.body.scheduledDate,
   };
-  const task = taskRepo.update(props);
+  const task = uow.taskRepo.update(props);
   if (task) {
     res.send(task);
   } else {
@@ -51,7 +45,7 @@ const updateByID = (req, res) => {
 };
 
 const deleteByID = (req, res) => {
-  const deletedTask = taskRepo.deleteByID(parseInt(req.params.id, 10));
+  const deletedTask = uow.taskRepo.deleteByID(parseInt(req.params.id, 10));
   if (deletedTask) {
     res.send(deletedTask);
   } else {

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -6,7 +6,7 @@ const getAll = (req, res) => {
   res.send(uow.taskRepo.getAll());
 };
 
-const getByID = (req, res) => {
+const getById = (req, res) => {
   const task = uow.taskRepo.getById(parseInt(req.params.id, 10));
   if (task) {
     res.send(task);
@@ -19,7 +19,7 @@ const create = (req, res) => {
   res.json(uow.createTask(req.body.title, parseInt(req.body.courseId, 10)));
 };
 
-const updateByID = (req, res) => {
+const updateById = (req, res) => {
   const props = {
     id: parseInt(req.params.id, 10),
     title: req.body.title,
@@ -36,8 +36,8 @@ const updateByID = (req, res) => {
   }
 };
 
-const deleteByID = (req, res) => {
-  const deletedTask = uow.taskRepo.deleteByID(parseInt(req.params.id, 10));
+const deleteById = (req, res) => {
+  const deletedTask = uow.taskRepo.deleteById(parseInt(req.params.id, 10));
   if (deletedTask) {
     res.send(deletedTask);
   } else {
@@ -47,8 +47,8 @@ const deleteByID = (req, res) => {
 
 module.exports = {
   getAll,
-  getByID,
+  getById,
   create,
-  updateByID,
-  deleteByID,
+  updateById,
+  deleteById,
 };

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -14,7 +14,7 @@ class CourseMemoryDAO {
   }
 
   newCourse(title) {
-    if (!validateTitle(title)) return undefined;
+    if (!validateTitle(title)) throw new Error('Courses must have a valid title');
     this.maxCourseId += 1;
     const course = new Course(this.maxCourseId, title);
     this.courses.push(course);

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -1,0 +1,10 @@
+const Course = require('./Course');
+
+class CourseMemoryDAO {
+  constructor() {
+    this.courses = [];
+    this.maxCourseId = 0;
+  }
+}
+
+module.exports = CourseMemoryDAO;

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -1,4 +1,5 @@
 const Course = require('./Course');
+const InMemoryDataStore = require('./InMemoryDataStore');
 
 const validateTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
 const validateUpdateCourseProps = (props) => (props && props.id && Number.isInteger(props.id));
@@ -11,27 +12,26 @@ const matchesCriteria = (course, criteria) => Object.keys(criteria).reduce((matc
 
 class CourseMemoryDAO {
   constructor() {
-    this.courses = [];
-    this.maxCourseId = 0;
+    this.data = InMemoryDataStore;
   }
 
   newCourse(title) {
     if (!validateTitle(title)) throw new Error('Courses must have a valid title');
-    this.maxCourseId += 1;
-    const course = new Course(this.maxCourseId, title);
-    this.courses.push(course);
+    this.data.maxCourseId += 1;
+    const course = new Course(this.data.maxCourseId, title);
+    this.data.courses.push(course);
     return course;
   }
 
   find(criteria) {
     if (!criteria || Object.keys(criteria).length === 0) {
-      return this.courses;
+      return this.data.courses;
     }
-    return this.courses.filter((course) => matchesCriteria(course, criteria));
+    return this.data.courses.filter((course) => matchesCriteria(course, criteria));
   }
 
   findById(id) {
-    return this.courses.find((course) => course.id === id);
+    return this.data.courses.find((course) => course.id === id);
   }
 
   updateCourse(props) {
@@ -44,9 +44,9 @@ class CourseMemoryDAO {
 
   deleteById(id) {
     if (!validateDeleteId(id)) throw new Error('Delete requires a valid id');
-    const courseIndex = this.courses.findIndex((t) => t.id === id);
+    const courseIndex = this.data.courses.findIndex((t) => t.id === id);
     if (courseIndex >= 0) {
-      return this.courses.splice(courseIndex, 1)[0];
+      return this.data.courses.splice(courseIndex, 1)[0];
     }
     return undefined;
   }

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -1,6 +1,7 @@
 const Course = require('./Course');
 
 const validateTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
+const validateUpdateCourseProps = (props) => (props && props.id && Number.isInteger(props.id));
 
 const matchesCriteria = (course, criteria) => Object.keys(criteria).reduce((matching, key) => {
   if (matching) return criteria[key] === course[key];
@@ -30,6 +31,14 @@ class CourseMemoryDAO {
 
   findById(id) {
     return this.courses.find((course) => course.id === id);
+  }
+
+  updateCourse(props) {
+    if (!validateUpdateCourseProps(props)) throw new Error('Updating requires a valid course id');
+    const course = this.findById(props.id);
+    return course && Object.assign(course, {
+      ...props.title && { title: props.title },
+    });
   }
 }
 

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -2,6 +2,7 @@ const Course = require('./Course');
 
 const validateTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
 const validateUpdateCourseProps = (props) => (props && props.id && Number.isInteger(props.id));
+const validateDeleteId = (id) => (id && Number.isInteger(id));
 
 const matchesCriteria = (course, criteria) => Object.keys(criteria).reduce((matching, key) => {
   if (matching) return criteria[key] === course[key];
@@ -42,6 +43,7 @@ class CourseMemoryDAO {
   }
 
   deleteById(id) {
+    if (!validateDeleteId(id)) throw new Error('Delete requires a valid id');
     const courseIndex = this.courses.findIndex((t) => t.id === id);
     if (courseIndex >= 0) {
       return this.courses.splice(courseIndex, 1)[0];

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -40,6 +40,14 @@ class CourseMemoryDAO {
       ...props.title && { title: props.title },
     });
   }
+
+  deleteById(id) {
+    const courseIndex = this.courses.findIndex((t) => t.id === id);
+    if (courseIndex >= 0) {
+      return this.courses.splice(courseIndex, 1)[0];
+    }
+    return undefined;
+  }
 }
 
 module.exports = CourseMemoryDAO;

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -1,9 +1,35 @@
 const Course = require('./Course');
 
+const validateTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
+
+const matchesCriteria = (course, criteria) => Object.keys(criteria).reduce((matching, key) => {
+  if (matching) return criteria[key] === course[key];
+  return false;
+}, true);
+
 class CourseMemoryDAO {
   constructor() {
     this.courses = [];
     this.maxCourseId = 0;
+  }
+
+  newCourse(title) {
+    if (!validateTitle(title)) return undefined;
+    this.maxCourseId += 1;
+    const course = new Course(this.maxCourseId, title);
+    this.courses.push(course);
+    return course;
+  }
+
+  find(criteria) {
+    if (!criteria || Object.keys(criteria).length === 0) {
+      return this.courses;
+    }
+    return this.courses.filter((course) => matchesCriteria(course, criteria));
+  }
+
+  findById(id) {
+    return this.courses.find((course) => course.id === id);
   }
 }
 

--- a/data/CourseMemoryDAO.js
+++ b/data/CourseMemoryDAO.js
@@ -1,9 +1,9 @@
 const Course = require('./Course');
 const InMemoryDataStore = require('./InMemoryDataStore');
 
-const validateTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
-const validateUpdateCourseProps = (props) => (props && props.id && Number.isInteger(props.id));
-const validateDeleteId = (id) => (id && Number.isInteger(id));
+const validateTitle = (title) => (title && typeof title === 'string');
+const validateUpdateCourseProps = (props) => (props && Number.isInteger(props.id));
+const validateDeleteId = (id) => Number.isInteger(id);
 
 const matchesCriteria = (course, criteria) => Object.keys(criteria).reduce((matching, key) => {
   if (matching) return criteria[key] === course[key];

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -8,6 +8,8 @@ const chai = require('chai');
 const should = chai.should();
 const CourseMemoryDAO = require('./CourseMemoryDAO');
 
+const Course = require('./Course');
+
 describe('CourseMemoryDAO', () => {
   describe('construction', () => {
     it('Should initialize with an empty course array and a maxCourseId of 0', () => {
@@ -24,8 +26,91 @@ describe('CourseMemoryDAO', () => {
     });
   });
   describe('newCourse()', () => {
-    it('Should add a new course with the provided title to the courses array', () => {
+    it('Should add the new course to the courses array', () => {
+      const dao = new CourseMemoryDAO();
+      chai.expect(dao.courses).to.have.lengthOf(0);
+      dao.newCourse('COURSE1');
+      chai.expect(dao.courses).to.have.lengthOf(1);
+      dao.newCourse('COURSE2');
+      chai.expect(dao.courses).to.have.lengthOf(2);
+    });
+    it('Should increment the maxCourseId by 1 to ensure uniqueness', () => {
+      const dao = new CourseMemoryDAO();
+      chai.expect(dao.maxCourseId).to.equal(0);
+      dao.newCourse('COURSE1');
+      chai.expect(dao.maxCourseId).to.equal(1);
+      dao.newCourse('COURSE2');
+      chai.expect(dao.maxCourseId).to.equal(2);
+    });
+    it('Should return a successfully created course', () => {
+      const dao = new CourseMemoryDAO();
+      const createdCourse = dao.newCourse('COURSE1');
+      chai.expect(createdCourse).to.be.ok;
+      chai.expect(createdCourse).to.haveOwnProperty('title');
+      chai.expect(createdCourse.title).to.be.equal('COURSE1');
+    });
+    it('Should return falsy if course creation is not successful', () => {
+      const dao = new CourseMemoryDAO();
+      chai.expect(dao.newCourse()).to.not.be.ok;
+      chai.expect(dao.newCourse({})).to.not.be.ok;
+      chai.expect(dao.newCourse({ title: 'COURSE1' })).to.not.be.ok;
+      chai.expect(dao.newCourse(12345)).to.not.be.ok;
+      chai.expect(dao.newCourse(true)).to.not.be.ok;
+    });
+  });
+  describe('find', () => {
+    let dao;
+    beforeEach(() => {
+      dao = new CourseMemoryDAO();
+      dao.newCourse('COURSE1');
+      dao.newCourse('COURSE2');
+      dao.newCourse('COURSE3');
+      dao.newCourse('COURSE4');
+      dao.newCourse('COURSE5');
+    });
+    it('Should return an array of all courses if no criteria is provided', () => {
+      chai.expect(dao.find()).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      chai.expect(dao.find({})).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      chai.expect(dao.find(null)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      chai.expect(dao.find(undefined)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+    });
+    it('Should return an array of all courses that match the criteria', () => {
+      chai.expect(dao.find({ title: 'COURSE1' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      chai.expect(dao.find({ id: 2 })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      chai.expect(dao.find({ title: 'COURSE2' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      chai.expect(dao.find({ title: 'COURSE5' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+    });
+    it('Should return an empty array if no courses match the criteria', () => {
+      chai.expect(dao.find({ title: 'COURSE12345' })).to.be.an.instanceOf(Array).and.to.be.empty;
+      chai.expect(dao.find({ title: 'COURSE12' })).to.be.an.instanceOf(Array).and.to.be.empty;
+      chai.expect(dao.find({ id: 12345 })).to.be.an.instanceOf(Array).and.to.be.empty;
+      chai.expect(dao.find({ randomProp: true })).to.be.an.instanceOf(Array).and.to.be.empty;
+    });
+  });
+  describe('findById', () => {
+    let dao;
+    beforeEach(() => {
+      dao = new CourseMemoryDAO();
+      dao.newCourse('COURSE1');
+      dao.newCourse('COURSE2');
+      dao.newCourse('COURSE3');
+      dao.newCourse('COURSE4');
+      dao.newCourse('COURSE5');
+    });
+    it('Should return the course with the given id if it exists in the courses array', () => {
+      chai.expect(dao.findById(1)).to.be.an.instanceOf(Course);
+      chai.expect(dao.findById(1).title).to.be.equal('COURSE1');
 
+      chai.expect(dao.findById(2)).to.be.an.instanceOf(Course);
+      chai.expect(dao.findById(2).title).to.be.equal('COURSE2');
+
+      chai.expect(dao.findById(3)).to.be.an.instanceOf(Course);
+      chai.expect(dao.findById(3).title).to.be.equal('COURSE3');
+    });
+    it('Should return falsy if the course with the given id does not exist in the courses array', () => {
+      chai.expect(dao.findById(1111)).to.not.be.ok;
+      chai.expect(dao.findById(555)).to.not.be.ok;
+      chai.expect(dao.findById()).to.not.be.ok;
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -129,6 +129,7 @@ describe('CourseMemoryDAO', () => {
   });
   describe('updateCourse', () => {
     let dao;
+
     beforeEach(() => {
       dao = new CourseMemoryDAO();
       dao.data.clear();
@@ -152,6 +153,7 @@ describe('CourseMemoryDAO', () => {
       expect(result).to.be.an.instanceOf(Course);
       expect(result.id).to.equal(2);
     });
+
     it('should return falsy if the course is not found', () => {
       let result = dao.updateCourse({ id: 123456, title: 'NOTEXIST123' });
       expect(result).to.not.be.ok;
@@ -159,6 +161,7 @@ describe('CourseMemoryDAO', () => {
       result = dao.updateCourse({ id: 999999, title: 'NOTEXIST123' });
       expect(result).to.not.be.ok;
     });
+
     it('should update the provided course properties (title) for the given course id', () => {
       let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
       expect(result).to.be.an.instanceOf(Course);
@@ -175,6 +178,7 @@ describe('CourseMemoryDAO', () => {
       expect(result.id).to.equal(3);
       expect(result.title).to.equal('NEWCOURSE3');
     });
+
     it('should throw an error if a valid course id is not provided in the props object', () => {
       expect(() => dao.updateCourse()).to.throw('Updating requires a valid course id');
       expect(() => dao.updateCourse({})).to.throw('Updating requires a valid course id');
@@ -188,6 +192,7 @@ describe('CourseMemoryDAO', () => {
   });
   describe('deleteById()', () => {
     let dao;
+
     beforeEach(() => {
       dao = new CourseMemoryDAO();
       dao.data.clear();
@@ -209,6 +214,7 @@ describe('CourseMemoryDAO', () => {
       expect(result.id).to.equal(courseIdToDelete);
       expect(result.title).to.equal('DEL123');
     });
+
     it('should remove the course from the courses array', () => {
       const courseIdToDelete = dao.newCourse('DEL123').id;
       expect(dao.data.courses).to.have.lengthOf(6);
@@ -217,15 +223,18 @@ describe('CourseMemoryDAO', () => {
       expect(dao.data.courses).to.have.lengthOf(5);
       expect(dao.findById(courseIdToDelete)).to.not.be.ok;
     });
+
     it('should return falsy if a course with the given id does not exist', () => {
       expect(dao.deleteById(100)).to.not.be.ok;
       expect(dao.deleteById(5555)).to.not.be.ok;
     });
+
     it('should not remove any courses from the courses array if a course with the given id is not found', () => {
       expect(dao.data.courses).to.have.lengthOf(5);
       dao.deleteById(1234567);
       expect(dao.data.courses).to.have.lengthOf(5);
     });
+
     it('should throw an error if a valid id is not passed in', () => {
       expect(() => dao.deleteById()).to.throw('Delete requires a valid id');
       expect(() => dao.deleteById({})).to.throw('Delete requires a valid id');

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /* eslint-disable no-plusplus */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
@@ -10,10 +11,21 @@ const CourseMemoryDAO = require('./CourseMemoryDAO');
 describe('CourseMemoryDAO', () => {
   describe('construction', () => {
     it('Should initialize with an empty course array and a maxCourseId of 0', () => {
-      /*const dao = new CourseMemoryDAO();
+      const dao = new CourseMemoryDAO();
       chai.expect(dao.courses).to.be.instanceOf(Array);
-      chai.except(dao.courses).to.be.empty();
-      chai.expect(dao.maxCourseId).to.be.equal(0);*/
+      chai.expect(dao.courses).to.be.empty;
+      chai.expect(dao.maxCourseId).to.be.equal(0);
+    });
+    it('Should not be affected by parameters', () => {
+      const dao = new CourseMemoryDAO([1, 2, 3], false, 'test');
+      chai.expect(dao.courses).to.be.instanceOf(Array);
+      chai.expect(dao.courses).to.be.empty;
+      chai.expect(dao.maxCourseId).to.be.equal(0);
+    });
+  });
+  describe('newCourse()', () => {
+    it('Should add a new course with the provided title to the courses array', () => {
+
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -7,50 +7,55 @@ const chai = require('chai');
 
 const should = chai.should();
 const CourseMemoryDAO = require('./CourseMemoryDAO');
+const InMemoryDataStore = require('./InMemoryDataStore');
 
 const Course = require('./Course');
 
 describe('CourseMemoryDAO', () => {
   describe('construction', () => {
-    it('Should initialize with an empty course array and a maxCourseId of 0', () => {
+    it('Should initialize with access to the in-memory data store object', () => {
       const dao = new CourseMemoryDAO();
-      chai.expect(dao.courses).to.be.instanceOf(Array);
-      chai.expect(dao.courses).to.be.empty;
-      chai.expect(dao.maxCourseId).to.be.equal(0);
+      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
     });
+
     it('Should not be affected by parameters', () => {
       const dao = new CourseMemoryDAO([1, 2, 3], false, 'test');
-      chai.expect(dao.courses).to.be.instanceOf(Array);
-      chai.expect(dao.courses).to.be.empty;
-      chai.expect(dao.maxCourseId).to.be.equal(0);
+      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
     });
   });
   describe('newCourse()', () => {
-    it('Should add the new course to the courses array', () => {
-      const dao = new CourseMemoryDAO();
-      chai.expect(dao.courses).to.have.lengthOf(0);
-      dao.newCourse('COURSE1');
-      chai.expect(dao.courses).to.have.lengthOf(1);
-      dao.newCourse('COURSE2');
-      chai.expect(dao.courses).to.have.lengthOf(2);
+    let dao;
+    beforeEach(() => {
+      dao = new CourseMemoryDAO();
+      dao.data.clear();
     });
-    it('Should increment the maxCourseId by 1 to ensure uniqueness', () => {
-      const dao = new CourseMemoryDAO();
-      chai.expect(dao.maxCourseId).to.equal(0);
+
+    afterEach(() => {
+      dao.data.clear();
+    });
+
+    it('Should add the new course to the courses array', () => {
+      chai.expect(dao.data.courses).to.have.lengthOf(0);
       dao.newCourse('COURSE1');
-      chai.expect(dao.maxCourseId).to.equal(1);
+      chai.expect(dao.data.courses).to.have.lengthOf(1);
       dao.newCourse('COURSE2');
-      chai.expect(dao.maxCourseId).to.equal(2);
+      chai.expect(dao.data.courses).to.have.lengthOf(2);
+    });
+
+    it('Should increment the maxCourseId by 1 to ensure uniqueness', () => {
+      chai.expect(dao.data.maxCourseId).to.equal(0);
+      dao.newCourse('COURSE1');
+      chai.expect(dao.data.maxCourseId).to.equal(1);
+      dao.newCourse('COURSE2');
+      chai.expect(dao.data.maxCourseId).to.equal(2);
     });
     it('Should return a successfully created course', () => {
-      const dao = new CourseMemoryDAO();
       const createdCourse = dao.newCourse('COURSE1');
       chai.expect(createdCourse).to.be.ok;
       chai.expect(createdCourse).to.haveOwnProperty('title');
       chai.expect(createdCourse.title).to.be.equal('COURSE1');
     });
     it('Should throw an error if input is not a string (invalid)', () => {
-      const dao = new CourseMemoryDAO();
       chai.expect(() => dao.newCourse()).to.throw('Courses must have a valid title');
       chai.expect(() => dao.newCourse({})).to.throw('Courses must have a valid title');
       chai.expect(() => dao.newCourse({ title: 'COURSE1' })).to.throw('Courses must have a valid title');
@@ -62,12 +67,18 @@ describe('CourseMemoryDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new CourseMemoryDAO();
+      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
       dao.newCourse('COURSE4');
       dao.newCourse('COURSE5');
     });
+
+    afterEach(() => {
+      dao.data.clear();
+    });
+
     it('Should return an array of all courses if no criteria is provided', () => {
       chai.expect(dao.find()).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
       chai.expect(dao.find({})).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
@@ -89,14 +100,21 @@ describe('CourseMemoryDAO', () => {
   });
   describe('findById', () => {
     let dao;
+
     beforeEach(() => {
       dao = new CourseMemoryDAO();
+      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
       dao.newCourse('COURSE4');
       dao.newCourse('COURSE5');
     });
+
+    afterEach(() => {
+      dao.data.clear();
+    });
+
     it('Should return the course with the given id if it exists in the courses array', () => {
       chai.expect(dao.findById(1)).to.be.an.instanceOf(Course);
       chai.expect(dao.findById(1).title).to.be.equal('COURSE1');
@@ -107,6 +125,7 @@ describe('CourseMemoryDAO', () => {
       chai.expect(dao.findById(3)).to.be.an.instanceOf(Course);
       chai.expect(dao.findById(3).title).to.be.equal('COURSE3');
     });
+
     it('Should return falsy if the course with the given id does not exist in the courses array', () => {
       chai.expect(dao.findById(1111)).to.not.be.ok;
       chai.expect(dao.findById(555)).to.not.be.ok;
@@ -117,12 +136,18 @@ describe('CourseMemoryDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new CourseMemoryDAO();
+      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
       dao.newCourse('COURSE4');
       dao.newCourse('COURSE5');
     });
+
+    afterEach(() => {
+      dao.data.clear();
+    });
+
     it('should return the updated course', () => {
       let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
       chai.expect(result).to.be.an.instanceOf(Course);
@@ -170,12 +195,18 @@ describe('CourseMemoryDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new CourseMemoryDAO();
+      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
       dao.newCourse('COURSE4');
       dao.newCourse('COURSE5');
     });
+
+    afterEach(() => {
+      dao.data.clear();
+    });
+
     it('should return the deleted course', () => {
       const courseIdToDelete = dao.newCourse('DEL123').id;
       const result = dao.deleteById(courseIdToDelete);
@@ -185,10 +216,10 @@ describe('CourseMemoryDAO', () => {
     });
     it('should remove the course from the courses array', () => {
       const courseIdToDelete = dao.newCourse('DEL123').id;
-      chai.expect(dao.courses).to.have.lengthOf(6);
+      chai.expect(dao.data.courses).to.have.lengthOf(6);
       chai.expect(dao.findById(courseIdToDelete)).to.be.an.instanceOf(Course);
       dao.deleteById(courseIdToDelete);
-      chai.expect(dao.courses).to.have.lengthOf(5);
+      chai.expect(dao.data.courses).to.have.lengthOf(5);
       chai.expect(dao.findById(courseIdToDelete)).to.not.be.ok;
     });
     it('should return falsy if a course with the given id does not exist', () => {
@@ -196,9 +227,9 @@ describe('CourseMemoryDAO', () => {
       chai.expect(dao.deleteById(5555)).to.not.be.ok;
     });
     it('should not remove any courses from the courses array if a course with the given id is not found', () => {
-      chai.expect(dao.courses).to.have.lengthOf(5);
+      chai.expect(dao.data.courses).to.have.lengthOf(5);
       dao.deleteById(1234567);
-      chai.expect(dao.courses).to.have.lengthOf(5);
+      chai.expect(dao.data.courses).to.have.lengthOf(5);
     });
     it('should throw an error if a valid id is not passed in', () => {
       chai.expect(() => dao.deleteById()).to.throw('Delete requires a valid id');

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -22,7 +22,6 @@ describe('CourseMemoryDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new CourseMemoryDAO();
-      dao.data.clear();
     });
 
     afterEach(() => {
@@ -62,7 +61,6 @@ describe('CourseMemoryDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new CourseMemoryDAO();
-      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
@@ -98,7 +96,6 @@ describe('CourseMemoryDAO', () => {
 
     beforeEach(() => {
       dao = new CourseMemoryDAO();
-      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
@@ -132,7 +129,6 @@ describe('CourseMemoryDAO', () => {
 
     beforeEach(() => {
       dao = new CourseMemoryDAO();
-      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');
@@ -195,7 +191,6 @@ describe('CourseMemoryDAO', () => {
 
     beforeEach(() => {
       dao = new CourseMemoryDAO();
-      dao.data.clear();
       dao.newCourse('COURSE1');
       dao.newCourse('COURSE2');
       dao.newCourse('COURSE3');

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -15,12 +15,12 @@ describe('CourseMemoryDAO', () => {
   describe('construction', () => {
     it('Should initialize with access to the in-memory data store object', () => {
       const dao = new CourseMemoryDAO();
-      expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.deep.equal(InMemoryDataStore);
     });
 
     it('Should not be affected by parameters', () => {
       const dao = new CourseMemoryDAO([1, 2, 3], false, 'test');
-      expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.deep.equal(InMemoryDataStore);
     });
   });
   describe('newCourse()', () => {

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -201,7 +201,12 @@ describe('CourseMemoryDAO', () => {
       chai.expect(dao.courses).to.have.lengthOf(5);
     });
     it('should throw an error if a valid id is not passed in', () => {
-      chai.expect(dao.deleteById()).to.throw('');
+      chai.expect(() => dao.deleteById()).to.throw('Delete requires a valid id');
+      chai.expect(() => dao.deleteById({})).to.throw('Delete requires a valid id');
+      chai.expect(() => dao.deleteById('12')).to.throw('Delete requires a valid id');
+      chai.expect(() => dao.deleteById(12.5)).to.throw('Delete requires a valid id');
+      chai.expect(() => dao.deleteById(true)).to.throw('Delete requires a valid id');
+      chai.expect(() => dao.deleteById(false)).to.throw('Delete requires a valid id');
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -49,13 +49,13 @@ describe('CourseMemoryDAO', () => {
       chai.expect(createdCourse).to.haveOwnProperty('title');
       chai.expect(createdCourse.title).to.be.equal('COURSE1');
     });
-    it('Should return falsy if course creation is not successful', () => {
+    it('Should throw an error if input is not a string (invalid)', () => {
       const dao = new CourseMemoryDAO();
-      chai.expect(dao.newCourse()).to.not.be.ok;
-      chai.expect(dao.newCourse({})).to.not.be.ok;
-      chai.expect(dao.newCourse({ title: 'COURSE1' })).to.not.be.ok;
-      chai.expect(dao.newCourse(12345)).to.not.be.ok;
-      chai.expect(dao.newCourse(true)).to.not.be.ok;
+      chai.expect(() => dao.newCourse()).to.throw('Courses must have a valid title');
+      chai.expect(() => dao.newCourse({})).to.throw('Courses must have a valid title');
+      chai.expect(() => dao.newCourse({ title: 'COURSE1' })).to.throw('Courses must have a valid title');
+      chai.expect(() => dao.newCourse(12345)).to.throw('Courses must have a valid title');
+      chai.expect(() => dao.newCourse(true)).to.throw('Courses must have a valid title');
     });
   });
   describe('find', () => {
@@ -111,6 +111,17 @@ describe('CourseMemoryDAO', () => {
       chai.expect(dao.findById(1111)).to.not.be.ok;
       chai.expect(dao.findById(555)).to.not.be.ok;
       chai.expect(dao.findById()).to.not.be.ok;
+    });
+  });
+  describe('updateCourse', () => {
+    it('should return the updated course', () => {
+
+    });
+    it('should return falsy if the course is not found', () => {
+
+    });
+    it('should update the provided task properties (title) for the given task id', () => {
+
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -166,4 +166,42 @@ describe('CourseMemoryDAO', () => {
       chai.expect(() => dao.updateCourse({ id: {}, title: 'NEW123' })).to.throw('Updating requires a valid course id');
     });
   });
+  describe('deleteById()', () => {
+    let dao;
+    beforeEach(() => {
+      dao = new CourseMemoryDAO();
+      dao.newCourse('COURSE1');
+      dao.newCourse('COURSE2');
+      dao.newCourse('COURSE3');
+      dao.newCourse('COURSE4');
+      dao.newCourse('COURSE5');
+    });
+    it('should return the deleted course', () => {
+      const courseIdToDelete = dao.newCourse('DEL123').id;
+      const result = dao.deleteById(courseIdToDelete);
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(courseIdToDelete);
+      chai.expect(result.title).to.equal('DEL123');
+    });
+    it('should remove the course from the courses array', () => {
+      const courseIdToDelete = dao.newCourse('DEL123').id;
+      chai.expect(dao.courses).to.have.lengthOf(6);
+      chai.expect(dao.findById(courseIdToDelete)).to.be.an.instanceOf(Course);
+      dao.deleteById(courseIdToDelete);
+      chai.expect(dao.courses).to.have.lengthOf(5);
+      chai.expect(dao.findById(courseIdToDelete)).to.not.be.ok;
+    });
+    it('should return falsy if a course with the given id does not exist', () => {
+      chai.expect(dao.deleteById(100)).to.not.be.ok;
+      chai.expect(dao.deleteById(5555)).to.not.be.ok;
+    });
+    it('should not remove any courses from the courses array if a course with the given id is not found', () => {
+      chai.expect(dao.courses).to.have.lengthOf(5);
+      dao.deleteById(1234567);
+      chai.expect(dao.courses).to.have.lengthOf(5);
+    });
+    it('should throw an error if a valid id is not passed in', () => {
+      chai.expect(dao.deleteById()).to.throw('');
+    });
+  });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -114,14 +114,56 @@ describe('CourseMemoryDAO', () => {
     });
   });
   describe('updateCourse', () => {
+    let dao;
+    beforeEach(() => {
+      dao = new CourseMemoryDAO();
+      dao.newCourse('COURSE1');
+      dao.newCourse('COURSE2');
+      dao.newCourse('COURSE3');
+      dao.newCourse('COURSE4');
+      dao.newCourse('COURSE5');
+    });
     it('should return the updated course', () => {
+      let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(1);
 
+      result = dao.updateCourse({ id: 2, title: 'NEWCOURSE2' });
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(2);
     });
     it('should return falsy if the course is not found', () => {
+      let result = dao.updateCourse({ id: 123456, title: 'NOTEXIST123' });
+      chai.expect(result).to.not.be.ok;
 
+      result = dao.updateCourse({ id: 999999, title: 'NOTEXIST123' });
+      chai.expect(result).to.not.be.ok;
     });
-    it('should update the provided task properties (title) for the given task id', () => {
+    it('should update the provided course properties (title) for the given course id', () => {
+      let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(1);
+      chai.expect(result.title).to.equal('NEWCOURSE1');
 
+      result = dao.updateCourse({ id: 2, title: 'NEWCOURSE2' });
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(2);
+      chai.expect(result.title).to.equal('NEWCOURSE2');
+
+      result = dao.updateCourse({ id: 3, title: 'NEWCOURSE3' });
+      chai.expect(result).to.be.an.instanceOf(Course);
+      chai.expect(result.id).to.equal(3);
+      chai.expect(result.title).to.equal('NEWCOURSE3');
+    });
+    it('should throw an error if a valid course id is not provided in the props object', () => {
+      chai.expect(() => dao.updateCourse()).to.throw('Updating requires a valid course id');
+      chai.expect(() => dao.updateCourse({})).to.throw('Updating requires a valid course id');
+      chai.expect(() => dao.updateCourse(null)).to.throw('Updating requires a valid course id');
+      chai.expect(() => dao.updateCourse({ title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      // must be an integer
+      chai.expect(() => dao.updateCourse({ id: true, title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      chai.expect(() => dao.updateCourse({ id: 'some string', title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      chai.expect(() => dao.updateCourse({ id: {}, title: 'NEW123' })).to.throw('Updating requires a valid course id');
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -5,7 +5,7 @@
 
 const chai = require('chai');
 
-const should = chai.should();
+const { expect } = chai;
 const CourseMemoryDAO = require('./CourseMemoryDAO');
 const InMemoryDataStore = require('./InMemoryDataStore');
 
@@ -15,12 +15,12 @@ describe('CourseMemoryDAO', () => {
   describe('construction', () => {
     it('Should initialize with access to the in-memory data store object', () => {
       const dao = new CourseMemoryDAO();
-      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.be.equal(InMemoryDataStore);
     });
 
     it('Should not be affected by parameters', () => {
       const dao = new CourseMemoryDAO([1, 2, 3], false, 'test');
-      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.be.equal(InMemoryDataStore);
     });
   });
   describe('newCourse()', () => {
@@ -35,32 +35,32 @@ describe('CourseMemoryDAO', () => {
     });
 
     it('Should add the new course to the courses array', () => {
-      chai.expect(dao.data.courses).to.have.lengthOf(0);
+      expect(dao.data.courses).to.have.lengthOf(0);
       dao.newCourse('COURSE1');
-      chai.expect(dao.data.courses).to.have.lengthOf(1);
+      expect(dao.data.courses).to.have.lengthOf(1);
       dao.newCourse('COURSE2');
-      chai.expect(dao.data.courses).to.have.lengthOf(2);
+      expect(dao.data.courses).to.have.lengthOf(2);
     });
 
     it('Should increment the maxCourseId by 1 to ensure uniqueness', () => {
-      chai.expect(dao.data.maxCourseId).to.equal(0);
+      expect(dao.data.maxCourseId).to.equal(0);
       dao.newCourse('COURSE1');
-      chai.expect(dao.data.maxCourseId).to.equal(1);
+      expect(dao.data.maxCourseId).to.equal(1);
       dao.newCourse('COURSE2');
-      chai.expect(dao.data.maxCourseId).to.equal(2);
+      expect(dao.data.maxCourseId).to.equal(2);
     });
     it('Should return a successfully created course', () => {
       const createdCourse = dao.newCourse('COURSE1');
-      chai.expect(createdCourse).to.be.ok;
-      chai.expect(createdCourse).to.haveOwnProperty('title');
-      chai.expect(createdCourse.title).to.be.equal('COURSE1');
+      expect(createdCourse).to.be.ok;
+      expect(createdCourse).to.haveOwnProperty('title');
+      expect(createdCourse.title).to.be.equal('COURSE1');
     });
     it('Should throw an error if input is not a string (invalid)', () => {
-      chai.expect(() => dao.newCourse()).to.throw('Courses must have a valid title');
-      chai.expect(() => dao.newCourse({})).to.throw('Courses must have a valid title');
-      chai.expect(() => dao.newCourse({ title: 'COURSE1' })).to.throw('Courses must have a valid title');
-      chai.expect(() => dao.newCourse(12345)).to.throw('Courses must have a valid title');
-      chai.expect(() => dao.newCourse(true)).to.throw('Courses must have a valid title');
+      expect(() => dao.newCourse()).to.throw('Courses must have a valid title');
+      expect(() => dao.newCourse({})).to.throw('Courses must have a valid title');
+      expect(() => dao.newCourse({ title: 'COURSE1' })).to.throw('Courses must have a valid title');
+      expect(() => dao.newCourse(12345)).to.throw('Courses must have a valid title');
+      expect(() => dao.newCourse(true)).to.throw('Courses must have a valid title');
     });
   });
   describe('find', () => {
@@ -80,22 +80,22 @@ describe('CourseMemoryDAO', () => {
     });
 
     it('Should return an array of all courses if no criteria is provided', () => {
-      chai.expect(dao.find()).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
-      chai.expect(dao.find({})).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
-      chai.expect(dao.find(null)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
-      chai.expect(dao.find(undefined)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      expect(dao.find()).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      expect(dao.find({})).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      expect(dao.find(null)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
+      expect(dao.find(undefined)).to.be.an.instanceOf(Array).and.to.have.lengthOf(5);
     });
     it('Should return an array of all courses that match the criteria', () => {
-      chai.expect(dao.find({ title: 'COURSE1' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
-      chai.expect(dao.find({ id: 2 })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
-      chai.expect(dao.find({ title: 'COURSE2' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
-      chai.expect(dao.find({ title: 'COURSE5' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      expect(dao.find({ title: 'COURSE1' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      expect(dao.find({ id: 2 })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      expect(dao.find({ title: 'COURSE2' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+      expect(dao.find({ title: 'COURSE5' })).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
     });
     it('Should return an empty array if no courses match the criteria', () => {
-      chai.expect(dao.find({ title: 'COURSE12345' })).to.be.an.instanceOf(Array).and.to.be.empty;
-      chai.expect(dao.find({ title: 'COURSE12' })).to.be.an.instanceOf(Array).and.to.be.empty;
-      chai.expect(dao.find({ id: 12345 })).to.be.an.instanceOf(Array).and.to.be.empty;
-      chai.expect(dao.find({ randomProp: true })).to.be.an.instanceOf(Array).and.to.be.empty;
+      expect(dao.find({ title: 'COURSE12345' })).to.be.an.instanceOf(Array).and.to.be.empty;
+      expect(dao.find({ title: 'COURSE12' })).to.be.an.instanceOf(Array).and.to.be.empty;
+      expect(dao.find({ id: 12345 })).to.be.an.instanceOf(Array).and.to.be.empty;
+      expect(dao.find({ randomProp: true })).to.be.an.instanceOf(Array).and.to.be.empty;
     });
   });
   describe('findById', () => {
@@ -116,20 +116,20 @@ describe('CourseMemoryDAO', () => {
     });
 
     it('Should return the course with the given id if it exists in the courses array', () => {
-      chai.expect(dao.findById(1)).to.be.an.instanceOf(Course);
-      chai.expect(dao.findById(1).title).to.be.equal('COURSE1');
+      expect(dao.findById(1)).to.be.an.instanceOf(Course);
+      expect(dao.findById(1).title).to.be.equal('COURSE1');
 
-      chai.expect(dao.findById(2)).to.be.an.instanceOf(Course);
-      chai.expect(dao.findById(2).title).to.be.equal('COURSE2');
+      expect(dao.findById(2)).to.be.an.instanceOf(Course);
+      expect(dao.findById(2).title).to.be.equal('COURSE2');
 
-      chai.expect(dao.findById(3)).to.be.an.instanceOf(Course);
-      chai.expect(dao.findById(3).title).to.be.equal('COURSE3');
+      expect(dao.findById(3)).to.be.an.instanceOf(Course);
+      expect(dao.findById(3).title).to.be.equal('COURSE3');
     });
 
     it('Should return falsy if the course with the given id does not exist in the courses array', () => {
-      chai.expect(dao.findById(1111)).to.not.be.ok;
-      chai.expect(dao.findById(555)).to.not.be.ok;
-      chai.expect(dao.findById()).to.not.be.ok;
+      expect(dao.findById(1111)).to.not.be.ok;
+      expect(dao.findById(555)).to.not.be.ok;
+      expect(dao.findById()).to.not.be.ok;
     });
   });
   describe('updateCourse', () => {
@@ -150,45 +150,45 @@ describe('CourseMemoryDAO', () => {
 
     it('should return the updated course', () => {
       let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(1);
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(1);
 
       result = dao.updateCourse({ id: 2, title: 'NEWCOURSE2' });
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(2);
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(2);
     });
     it('should return falsy if the course is not found', () => {
       let result = dao.updateCourse({ id: 123456, title: 'NOTEXIST123' });
-      chai.expect(result).to.not.be.ok;
+      expect(result).to.not.be.ok;
 
       result = dao.updateCourse({ id: 999999, title: 'NOTEXIST123' });
-      chai.expect(result).to.not.be.ok;
+      expect(result).to.not.be.ok;
     });
     it('should update the provided course properties (title) for the given course id', () => {
       let result = dao.updateCourse({ id: 1, title: 'NEWCOURSE1' });
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(1);
-      chai.expect(result.title).to.equal('NEWCOURSE1');
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(1);
+      expect(result.title).to.equal('NEWCOURSE1');
 
       result = dao.updateCourse({ id: 2, title: 'NEWCOURSE2' });
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(2);
-      chai.expect(result.title).to.equal('NEWCOURSE2');
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(2);
+      expect(result.title).to.equal('NEWCOURSE2');
 
       result = dao.updateCourse({ id: 3, title: 'NEWCOURSE3' });
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(3);
-      chai.expect(result.title).to.equal('NEWCOURSE3');
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(3);
+      expect(result.title).to.equal('NEWCOURSE3');
     });
     it('should throw an error if a valid course id is not provided in the props object', () => {
-      chai.expect(() => dao.updateCourse()).to.throw('Updating requires a valid course id');
-      chai.expect(() => dao.updateCourse({})).to.throw('Updating requires a valid course id');
-      chai.expect(() => dao.updateCourse(null)).to.throw('Updating requires a valid course id');
-      chai.expect(() => dao.updateCourse({ title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse()).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse({})).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse(null)).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse({ title: 'NEW123' })).to.throw('Updating requires a valid course id');
       // must be an integer
-      chai.expect(() => dao.updateCourse({ id: true, title: 'NEW123' })).to.throw('Updating requires a valid course id');
-      chai.expect(() => dao.updateCourse({ id: 'some string', title: 'NEW123' })).to.throw('Updating requires a valid course id');
-      chai.expect(() => dao.updateCourse({ id: {}, title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse({ id: true, title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse({ id: 'some string', title: 'NEW123' })).to.throw('Updating requires a valid course id');
+      expect(() => dao.updateCourse({ id: {}, title: 'NEW123' })).to.throw('Updating requires a valid course id');
     });
   });
   describe('deleteById()', () => {
@@ -210,34 +210,34 @@ describe('CourseMemoryDAO', () => {
     it('should return the deleted course', () => {
       const courseIdToDelete = dao.newCourse('DEL123').id;
       const result = dao.deleteById(courseIdToDelete);
-      chai.expect(result).to.be.an.instanceOf(Course);
-      chai.expect(result.id).to.equal(courseIdToDelete);
-      chai.expect(result.title).to.equal('DEL123');
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.equal(courseIdToDelete);
+      expect(result.title).to.equal('DEL123');
     });
     it('should remove the course from the courses array', () => {
       const courseIdToDelete = dao.newCourse('DEL123').id;
-      chai.expect(dao.data.courses).to.have.lengthOf(6);
-      chai.expect(dao.findById(courseIdToDelete)).to.be.an.instanceOf(Course);
+      expect(dao.data.courses).to.have.lengthOf(6);
+      expect(dao.findById(courseIdToDelete)).to.be.an.instanceOf(Course);
       dao.deleteById(courseIdToDelete);
-      chai.expect(dao.data.courses).to.have.lengthOf(5);
-      chai.expect(dao.findById(courseIdToDelete)).to.not.be.ok;
+      expect(dao.data.courses).to.have.lengthOf(5);
+      expect(dao.findById(courseIdToDelete)).to.not.be.ok;
     });
     it('should return falsy if a course with the given id does not exist', () => {
-      chai.expect(dao.deleteById(100)).to.not.be.ok;
-      chai.expect(dao.deleteById(5555)).to.not.be.ok;
+      expect(dao.deleteById(100)).to.not.be.ok;
+      expect(dao.deleteById(5555)).to.not.be.ok;
     });
     it('should not remove any courses from the courses array if a course with the given id is not found', () => {
-      chai.expect(dao.data.courses).to.have.lengthOf(5);
+      expect(dao.data.courses).to.have.lengthOf(5);
       dao.deleteById(1234567);
-      chai.expect(dao.data.courses).to.have.lengthOf(5);
+      expect(dao.data.courses).to.have.lengthOf(5);
     });
     it('should throw an error if a valid id is not passed in', () => {
-      chai.expect(() => dao.deleteById()).to.throw('Delete requires a valid id');
-      chai.expect(() => dao.deleteById({})).to.throw('Delete requires a valid id');
-      chai.expect(() => dao.deleteById('12')).to.throw('Delete requires a valid id');
-      chai.expect(() => dao.deleteById(12.5)).to.throw('Delete requires a valid id');
-      chai.expect(() => dao.deleteById(true)).to.throw('Delete requires a valid id');
-      chai.expect(() => dao.deleteById(false)).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById()).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById({})).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById('12')).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById(12.5)).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById(true)).to.throw('Delete requires a valid id');
+      expect(() => dao.deleteById(false)).to.throw('Delete requires a valid id');
     });
   });
 });

--- a/data/CourseMemoryDAO.test.js
+++ b/data/CourseMemoryDAO.test.js
@@ -1,8 +1,3 @@
-/* eslint-disable no-unused-expressions */
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const { expect } = chai;

--- a/data/CourseRepository.js
+++ b/data/CourseRepository.js
@@ -1,0 +1,27 @@
+class CourseRepository {
+  constructor(dao) {
+    this.dao = dao;
+  }
+
+  getAll() {
+    return this.dao.find({});
+  }
+
+  getById(id) {
+    return this.dao.findById(id);
+  }
+
+  update(props) {
+    return this.dao.updateTask(props);
+  }
+
+  newCourse(title) {
+    return this.dao.newCourse(title);
+  }
+
+  deleteById(id) {
+    return this.dao.deleteById(id);
+  }
+}
+
+module.exports = CourseRepository;

--- a/data/CourseRepository.js
+++ b/data/CourseRepository.js
@@ -12,7 +12,7 @@ class CourseRepository {
   }
 
   update(props) {
-    return this.dao.updateTask(props);
+    return this.dao.updateCourse(props);
   }
 
   newCourse(title) {

--- a/data/CourseRepository.test.js
+++ b/data/CourseRepository.test.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const should = chai.should();

--- a/data/CourseRepository.test.js
+++ b/data/CourseRepository.test.js
@@ -169,7 +169,7 @@ describe('CourseRepository', () => {
       expect(() => courseRepo.deleteById(false)).to.throw('Delete requires a valid id');
       expect(() => courseRepo.deleteById(undefined)).to.throw('Delete requires a valid id');
     });
-    
+
     it('should return falsy if a course with id does not exist', () => {
       let result = courseRepo.deleteById(-1);
       expect(result).to.not.be.ok;

--- a/data/CourseRepository.test.js
+++ b/data/CourseRepository.test.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+
+const chai = require('chai');
+
+const should = chai.should();
+const CourseMemoryDAO = require('./CourseMemoryDAO');
+const CourseRepository = require('./CourseRepository');
+
+const Course = require('./Course');
+
+describe('CourseRepository', () => {
+  describe('construction', () => {
+
+  });
+});

--- a/data/CourseRepository.test.js
+++ b/data/CourseRepository.test.js
@@ -16,7 +16,6 @@ describe('CourseRepository', () => {
 
   describe('getAll', () => {
     const courseRepo = new CourseRepository(new CourseMemoryDAO());
-    InMemoryDataStore.clear();
 
     afterEach(() => {
       InMemoryDataStore.clear();
@@ -38,7 +37,6 @@ describe('CourseRepository', () => {
 
   describe('getById', () => {
     const courseRepo = new CourseRepository(new CourseMemoryDAO());
-    InMemoryDataStore.clear();
 
     beforeEach(() => {
       courseRepo.newCourse('Course 1');
@@ -66,7 +64,6 @@ describe('CourseRepository', () => {
 
   describe('update', () => {
     const courseRepo = new CourseRepository(new CourseMemoryDAO());
-    InMemoryDataStore.clear();
 
     beforeEach(() => {
       courseRepo.newCourse('Course 1');
@@ -105,7 +102,6 @@ describe('CourseRepository', () => {
 
   describe('newCourse', () => {
     const courseRepo = new CourseRepository(new CourseMemoryDAO());
-    InMemoryDataStore.clear();
 
     afterEach(() => {
       InMemoryDataStore.clear();
@@ -135,7 +131,6 @@ describe('CourseRepository', () => {
 
   describe('deleteById', () => {
     const courseRepo = new CourseRepository(new CourseMemoryDAO());
-    InMemoryDataStore.clear();
 
     beforeEach(() => {
       courseRepo.newCourse('Course 1');

--- a/data/CourseRepository.test.js
+++ b/data/CourseRepository.test.js
@@ -1,13 +1,180 @@
 const chai = require('chai');
 
-const should = chai.should();
+const { expect } = chai;
 const CourseMemoryDAO = require('./CourseMemoryDAO');
 const CourseRepository = require('./CourseRepository');
-
+const InMemoryDataStore = require('./InMemoryDataStore');
 const Course = require('./Course');
 
 describe('CourseRepository', () => {
   describe('construction', () => {
+    it('should initialize with the passed in dao', () => {
+      const courseRepo = new CourseRepository(new CourseMemoryDAO());
+      expect(courseRepo.dao).to.be.an.instanceOf(CourseMemoryDAO);
+    });
+  });
 
+  describe('getAll', () => {
+    const courseRepo = new CourseRepository(new CourseMemoryDAO());
+    InMemoryDataStore.clear();
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+
+    it('should return an empty array if no courses exist', () => {
+      const result = courseRepo.getAll();
+      expect(result).to.be.an.instanceOf(Array).and.to.be.empty;
+    });
+
+    it('should return an array of all courses', () => {
+      courseRepo.newCourse('Course 1');
+      courseRepo.newCourse('Course 2');
+      courseRepo.newCourse('Course 3');
+      const result = courseRepo.getAll();
+      expect(result).to.be.an.instanceOf(Array).and.to.have.lengthOf(3);
+    });
+  });
+
+  describe('getById', () => {
+    const courseRepo = new CourseRepository(new CourseMemoryDAO());
+    InMemoryDataStore.clear();
+
+    beforeEach(() => {
+      courseRepo.newCourse('Course 1');
+      courseRepo.newCourse('Course 2');
+      courseRepo.newCourse('Course 3');
+    });
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+
+    it('should return the course', () => {
+      const result = courseRepo.getById(1);
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.be.equal(1);
+    });
+
+    it('should return falsy if the course with the given id does not exist', () => {
+      let result = courseRepo.getById(-1);
+      expect(result).to.not.be.ok;
+      result = courseRepo.getById(999999);
+      expect(result).to.not.be.ok;
+    });
+  });
+
+  describe('update', () => {
+    const courseRepo = new CourseRepository(new CourseMemoryDAO());
+    InMemoryDataStore.clear();
+
+    beforeEach(() => {
+      courseRepo.newCourse('Course 1');
+      courseRepo.newCourse('Course 2');
+      courseRepo.newCourse('Course 3');
+    });
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+
+    it('should return the updated course', () => {
+      const result = courseRepo.update({ id: 2 });
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.id).to.be.equal(2);
+    });
+
+    it('should throw an error if id is not provided', () => {
+      expect(() => courseRepo.update()).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update('.jr3')).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update('33')).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update(null)).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update(undefined)).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update({})).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update(true)).to.throw('Updating requires a valid course id');
+      expect(() => courseRepo.update(false)).to.throw('Updating requires a valid course id');
+    });
+
+    it('should return falsy if course with the given id does not exist', () => {
+      let result = courseRepo.update({ id: 777777 });
+      expect(result).to.not.be.ok;
+      result = courseRepo.update({ id: -1 });
+      expect(result).to.not.be.ok;
+    });
+  });
+
+  describe('newCourse', () => {
+    const courseRepo = new CourseRepository(new CourseMemoryDAO());
+    InMemoryDataStore.clear();
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+    it('should return the new course', () => {
+      const result = courseRepo.newCourse('Course 1');
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.title).to.be.equal('Course 1');
+    });
+
+    it('should add the new course to the datastore/database', () => {
+      const newCourseId = courseRepo.newCourse('Course 1').id;
+      const result = courseRepo.getById(newCourseId);
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.title).to.be.equal('Course 1');
+    });
+
+    it('should throw an error if the title is not valid', () => {
+      expect(() => courseRepo.newCourse()).to.throw('Courses must have a valid title');
+      expect(() => courseRepo.newCourse(true)).to.throw('Courses must have a valid title');
+      expect(() => courseRepo.newCourse(false)).to.throw('Courses must have a valid title');
+      expect(() => courseRepo.newCourse(1234)).to.throw('Courses must have a valid title');
+      expect(() => courseRepo.newCourse({})).to.throw('Courses must have a valid title');
+      expect(() => courseRepo.newCourse({ title: 'Course 1' })).to.throw('Courses must have a valid title');
+    });
+  });
+
+  describe('deleteById', () => {
+    const courseRepo = new CourseRepository(new CourseMemoryDAO());
+    InMemoryDataStore.clear();
+
+    beforeEach(() => {
+      courseRepo.newCourse('Course 1');
+      courseRepo.newCourse('Course 2');
+      courseRepo.newCourse('Course 3');
+    });
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+
+    it('should return the deleted course', () => {
+      const deleteId = courseRepo.newCourse('Course to Delete').id;
+      const result = courseRepo.deleteById(deleteId);
+      expect(result).to.be.an.instanceOf(Course);
+      expect(result.title).to.be.equal('Course to Delete');
+    });
+
+    it('should remove the course from the datastore/database', () => {
+      const deleteId = courseRepo.newCourse('Course to Delete').id;
+      expect(courseRepo.getById(deleteId)).to.be.an.instanceOf(Course);
+      courseRepo.deleteById(deleteId);
+      expect(courseRepo.getById(deleteId)).to.not.be.ok;
+    });
+
+    it('should throw an error if the id is not valid', () => {
+      expect(() => courseRepo.deleteById()).to.throw('Delete requires a valid id');
+      expect(() => courseRepo.deleteById('foo')).to.throw('Delete requires a valid id');
+      expect(() => courseRepo.deleteById({ id: 10 })).to.throw('Delete requires a valid id');
+      expect(() => courseRepo.deleteById({})).to.throw('Delete requires a valid id');
+      expect(() => courseRepo.deleteById(false)).to.throw('Delete requires a valid id');
+      expect(() => courseRepo.deleteById(undefined)).to.throw('Delete requires a valid id');
+    });
+    
+    it('should return falsy if a course with id does not exist', () => {
+      let result = courseRepo.deleteById(-1);
+      expect(result).to.not.be.ok;
+      result = courseRepo.deleteById(9999999999);
+      expect(result).to.not.be.ok;
+    });
   });
 });

--- a/data/InMemoryDataStore.js
+++ b/data/InMemoryDataStore.js
@@ -1,0 +1,19 @@
+function data() {
+  const that = {
+    tasks: [],
+    courses: [],
+    maxCourseId: 0,
+    maxTaskId: 0,
+  };
+  that.clear = () => {
+    that.tasks = [];
+    that.courses = [];
+    that.maxCourseId = 0;
+    that.maxTaskId = 0;
+  };
+  return that;
+}
+
+const dataStore = data();
+
+module.exports = dataStore;

--- a/data/InMemoryDataStore.js
+++ b/data/InMemoryDataStore.js
@@ -1,4 +1,4 @@
-function data() {
+function dataStore() {
   const that = {
     tasks: [],
     courses: [],
@@ -14,6 +14,5 @@ function data() {
   return that;
 }
 
-const dataStore = data();
 
-module.exports = dataStore;
+module.exports = dataStore();

--- a/data/InMemoryDataStore.test.js
+++ b/data/InMemoryDataStore.test.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const { expect } = chai;

--- a/data/InMemoryDataStore.test.js
+++ b/data/InMemoryDataStore.test.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+
+const chai = require('chai');
+
+const should = chai.should();
+const InMemoryDataStore = require('./InMemoryDataStore');
+
+const Course = require('./Course');
+
+describe('InMemoryDataStore', () => {
+  describe('clear', () => {
+    it('should clear contents and restore default of the data store', () => {
+      InMemoryDataStore.courses = [1, 2, 3];
+      InMemoryDataStore.tasks = [1, 2, 3];
+      InMemoryDataStore.maxCourseId = 3;
+      InMemoryDataStore.maxTaskId = 3;
+      chai.expect(InMemoryDataStore.courses).to.have.lengthOf(3);
+      chai.expect(InMemoryDataStore.tasks).to.have.lengthOf(3);
+      chai.expect(InMemoryDataStore.maxCourseId).to.equal(3);
+      chai.expect(InMemoryDataStore.maxTaskId).to.equal(3);
+      InMemoryDataStore.clear();
+      chai.expect(InMemoryDataStore.courses).to.have.lengthOf(0);
+      chai.expect(InMemoryDataStore.tasks).to.have.lengthOf(0);
+      chai.expect(InMemoryDataStore.maxCourseId).to.equal(0);
+      chai.expect(InMemoryDataStore.maxTaskId).to.equal(0);
+    });
+  });
+});

--- a/data/InMemoryDataStore.test.js
+++ b/data/InMemoryDataStore.test.js
@@ -4,7 +4,7 @@
 
 const chai = require('chai');
 
-const should = chai.should();
+const { expect } = chai;
 const InMemoryDataStore = require('./InMemoryDataStore');
 
 const Course = require('./Course');
@@ -16,15 +16,15 @@ describe('InMemoryDataStore', () => {
       InMemoryDataStore.tasks = [1, 2, 3];
       InMemoryDataStore.maxCourseId = 3;
       InMemoryDataStore.maxTaskId = 3;
-      chai.expect(InMemoryDataStore.courses).to.have.lengthOf(3);
-      chai.expect(InMemoryDataStore.tasks).to.have.lengthOf(3);
-      chai.expect(InMemoryDataStore.maxCourseId).to.equal(3);
-      chai.expect(InMemoryDataStore.maxTaskId).to.equal(3);
+      expect(InMemoryDataStore.courses).to.have.lengthOf(3);
+      expect(InMemoryDataStore.tasks).to.have.lengthOf(3);
+      expect(InMemoryDataStore.maxCourseId).to.equal(3);
+      expect(InMemoryDataStore.maxTaskId).to.equal(3);
       InMemoryDataStore.clear();
-      chai.expect(InMemoryDataStore.courses).to.have.lengthOf(0);
-      chai.expect(InMemoryDataStore.tasks).to.have.lengthOf(0);
-      chai.expect(InMemoryDataStore.maxCourseId).to.equal(0);
-      chai.expect(InMemoryDataStore.maxTaskId).to.equal(0);
+      expect(InMemoryDataStore.courses).to.have.lengthOf(0);
+      expect(InMemoryDataStore.tasks).to.have.lengthOf(0);
+      expect(InMemoryDataStore.maxCourseId).to.equal(0);
+      expect(InMemoryDataStore.maxTaskId).to.equal(0);
     });
   });
 });

--- a/data/Task.js
+++ b/data/Task.js
@@ -1,8 +1,8 @@
 class Task {
-  constructor(id, title, course, deadline = null, completed = false, scheduledDate = null) {
+  constructor(id, title, courseId, deadline = null, completed = false, scheduledDate = null) {
     this.id = id;
     this.title = title;
-    this.course = course;
+    this.courseId = courseId;
     this.deadline = deadline;
     this.completed = completed;
     this.scheduledDate = scheduledDate;

--- a/data/TaskMemoryDAO.js
+++ b/data/TaskMemoryDAO.js
@@ -1,4 +1,5 @@
 const Task = require('./Task');
+const InMemoryDataStore = require('./InMemoryDataStore');
 
 // meant to be private helper-methods
 const matchesCriteria = (task, criteria) => Object.keys(criteria).reduce((matching, key) => {
@@ -15,33 +16,32 @@ const validateUpdateTaskProps = (props = {}) => (props && props.id);
 // In-memory implementation
 class TaskMemoryDAO {
   constructor() {
-    this.tasks = [];
-    this.maxId = 0;
+    this.data = InMemoryDataStore;
   }
 
   find(criteria) {
     if (!criteria || Object.keys(criteria).length === 0) {
-      return this.tasks;
+      return this.data.tasks;
     }
-    return this.tasks.filter((task) => matchesCriteria(task, criteria));
+    return this.data.tasks.filter((task) => matchesCriteria(task, criteria));
   }
 
   findById(id) {
-    return this.tasks.find((task) => task.id === id);
+    return this.data.tasks.find((task) => task.id === id);
   }
 
   newTask(props) {
     if (!validateNewTaskProps(props)) return undefined;
-    this.maxId += 1;
+    this.data.maxTaskId += 1;
     const task = new Task(
-      this.maxId,
+      this.data.maxTaskId,
       props.title,
       props.courseId,
       props.deadline,
       props.completed,
       props.scheduledDate,
     );
-    this.tasks.push(task);
+    this.data.tasks.push(task);
     return task;
   }
 
@@ -59,9 +59,9 @@ class TaskMemoryDAO {
 
   // might be better to just have a deleted flag?
   deleteById(id) {
-    const taskIndex = this.tasks.findIndex((t) => t.id === id);
+    const taskIndex = this.data.tasks.findIndex((t) => t.id === id);
     if (taskIndex >= 0) {
-      return this.tasks.splice(taskIndex, 1)[0];
+      return this.data.tasks.splice(taskIndex, 1)[0];
     }
     return undefined;
   }

--- a/data/TaskMemoryDAO.js
+++ b/data/TaskMemoryDAO.js
@@ -6,8 +6,10 @@ const matchesCriteria = (task, criteria) => Object.keys(criteria).reduce((matchi
   return false;
 }, true);
 
-const validateNewTaskProps = (props = {}) => (props && props.title && props.course);
-
+const validateNewTaskProps = (props = {}) => (props
+                                              && props.title
+                                              && props.courseId
+                                              && Number.isInteger(props.courseId));
 const validateUpdateTaskProps = (props = {}) => (props && props.id);
 
 // In-memory implementation
@@ -34,7 +36,7 @@ class TaskMemoryDAO {
     const task = new Task(
       this.maxId,
       props.title,
-      props.course,
+      props.courseId,
       props.deadline,
       props.completed,
       props.scheduledDate,
@@ -48,7 +50,7 @@ class TaskMemoryDAO {
     const task = this.findById(props.id);
     return task && Object.assign(task, {
       ...props.title && { title: props.title },
-      ...props.course && { course: props.course },
+      ...props.courseId && { courseId: props.courseId },
       ...props.deadline && { deadline: props.deadline },
       ...props.completed && { completed: props.completed },
       ...props.scheduledDate && { scheduledDate: props.scheduledDate },

--- a/data/TaskMemoryDAO.js
+++ b/data/TaskMemoryDAO.js
@@ -9,7 +9,6 @@ const matchesCriteria = (task, criteria) => Object.keys(criteria).reduce((matchi
 
 const validateNewTaskProps = (props = {}) => (props
                                               && props.title
-                                              && props.courseId
                                               && Number.isInteger(props.courseId));
 const validateUpdateTaskProps = (props = {}) => (props && props.id);
 

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -35,24 +35,24 @@ describe('In-Memory TaskDAO', () => {
       chai.assert.isNotOk(dao.newTask(undefined));
       chai.assert.isNotOk(dao.newTask({}));
       chai.assert.isNotOk(dao.newTask(12));
-      chai.assert.isNotOk(dao.newTask(title = 'something', course = 'eo')); // param is not an object
+      chai.assert.isNotOk(dao.newTask(title = 'something', courseId = 1)); // param is not an object
 
       chai.assert.isNotOk(dao.newTask({ title: 'some task' }));
-      chai.assert.isNotOk(dao.newTask({ course: 'course7889' }));
+      chai.assert.isNotOk(dao.newTask({ courseId: 7 }));
       chai.assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
-      chai.assert.isNotOk(dao.newTask({ course: 'course7889', otherProp: 'some other property' }));
+      chai.assert.isNotOk(dao.newTask({ courseId: 1, otherProp: 'some other property' }));
       chai.assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
     });
     it('should return a successfully created task', () => {
       const dao = new TaskMemoryDAO();
-      const task = dao.newTask({ title: 'my task', course: 'CS5000' });
+      const task = dao.newTask({ title: 'my task', courseId: 5 });
       chai.assert.isOk(task);
       chai.assert.strictEqual(task.title, 'my task');
-      chai.assert.strictEqual(task.course, 'CS5000');
+      chai.assert.strictEqual(task.courseId, 5);
     });
     it('should set default values for non-required properties', () => {
       const dao = new TaskMemoryDAO();
-      const task = dao.newTask({ title: 'my task', course: 'CS5000' });
+      const task = dao.newTask({ title: 'my task', courseId: 5 });
       chai.assert.isOk(task);
       chai.assert.isNumber(task.id);
       chai.assert.isNull(task.deadline);
@@ -63,14 +63,14 @@ describe('In-Memory TaskDAO', () => {
       const dao = new TaskMemoryDAO();
       const props = {
         title: 'my task',
-        course: 'CS5000',
+        courseId: 5,
         deadline: 'Jan 4, 2020',
         completed: true,
         scheduledDate: 'Jan 1, 2020',
       };
       const task = dao.newTask(props);
       chai.assert.strictEqual(task.title, 'my task');
-      chai.assert.strictEqual(task.course, 'CS5000');
+      chai.assert.strictEqual(task.courseId, 5);
       chai.assert.strictEqual(task.deadline, 'Jan 4, 2020');
       chai.assert.isTrue(task.completed);
       chai.assert.strictEqual(task.scheduledDate, 'Jan 1, 2020');
@@ -78,20 +78,20 @@ describe('In-Memory TaskDAO', () => {
     it('should add the new task to the tasks array', () => {
       const dao = new TaskMemoryDAO();
 
-      dao.newTask({ title: 'my task', course: 'CS5000' });
+      dao.newTask({ title: 'my task', courseId: 10 });
       chai.assert.lengthOf(dao.tasks, 1);
       chai.assert.strictEqual(dao.tasks[0].title, 'my task');
-      chai.assert.strictEqual(dao.tasks[0].course, 'CS5000');
+      chai.assert.strictEqual(dao.tasks[0].courseId, 10);
 
-      dao.newTask({ title: 'my task2', course: 'MS3000' });
+      dao.newTask({ title: 'my task2', courseId: 3 });
       chai.assert.lengthOf(dao.tasks, 2);
       chai.assert.strictEqual(dao.tasks[1].title, 'my task2');
-      chai.assert.strictEqual(dao.tasks[1].course, 'MS3000');
+      chai.assert.strictEqual(dao.tasks[1].courseId, 3);
 
-      dao.newTask({ title: 'my task3', course: 'ENGL3000' });
+      dao.newTask({ title: 'my task3', courseId: 6 });
       chai.assert.lengthOf(dao.tasks, 3);
       chai.assert.strictEqual(dao.tasks[2].title, 'my task3');
-      chai.assert.strictEqual(dao.tasks[2].course, 'ENGL3000');
+      chai.assert.strictEqual(dao.tasks[2].courseId, 6);
     });
   });
   describe('Querying', () => {
@@ -99,7 +99,7 @@ describe('In-Memory TaskDAO', () => {
       it('find returns all tasks when no search criteria is used', () => {
         const dao = new TaskMemoryDAO();
         for (let i = 1; i <= 10; i++) {
-          dao.newTask({ title: `some task ${i}`, course: `CS500${i}` });
+          dao.newTask({ title: `some task ${i}`, courseId: i });
         }
         chai.assert.lengthOf(dao.find(), 10);
         chai.assert.lengthOf(dao.find({}), 10);
@@ -107,18 +107,18 @@ describe('In-Memory TaskDAO', () => {
       });
       it('returns an array of all tasks that exactly match single-attribute criteria', () => {
         const dao = new TaskMemoryDAO();
-        dao.newTask({ title: 'task1', course: 'CS5000', completed: true });
-        dao.newTask({ title: 'task2', course: 'CS4000' });
-        dao.newTask({ title: 'task3', course: 'CS5555' });
-        dao.newTask({ title: 'task4', course: 'CS5000' });
-        dao.newTask({ title: 'task5', course: 'CS5980' });
-        dao.newTask({ title: 'task6', course: 'CS3000' });
+        dao.newTask({ title: 'task1', courseId: 5, completed: true });
+        dao.newTask({ title: 'task2', courseId: 4 });
+        dao.newTask({ title: 'task3', courseId: 55 });
+        dao.newTask({ title: 'task4', courseId: 5 });
+        dao.newTask({ title: 'task5', courseId: 59 });
+        dao.newTask({ title: 'task6', courseId: 3 });
 
         let result = dao.find({ title: 'task4' });
         chai.assert.isArray(result);
         chai.assert.lengthOf(result, 1);
 
-        result = dao.find({ course: 'CS5000' });
+        result = dao.find({ courseId: 5 });
         chai.assert.isArray(result);
         chai.assert.lengthOf(result, 2);
 
@@ -132,25 +132,25 @@ describe('In-Memory TaskDAO', () => {
       });
       it('returns an array of all tasks that exactly match multi-attribute criteria', () => {
         const dao = new TaskMemoryDAO();
-        dao.newTask({ title: 'task1', course: 'CS5000', completed: true });
-        dao.newTask({ title: 'task2', course: 'CS4000' });
-        dao.newTask({ title: 'task3', course: 'CS5555' });
-        dao.newTask({ title: 'task4', course: 'CS5000' });
-        dao.newTask({ title: 'task5', course: 'CS5980' });
-        dao.newTask({ title: 'task6', course: 'CS3000', completed: true });
-        dao.newTask({ title: 'task7', course: 'CS3000' });
-        dao.newTask({ title: 'task8', course: 'CS3000' });
-        dao.newTask({ title: 'task9', course: 'CS3000' });
+        dao.newTask({ title: 'task1', courseId: 5, completed: true });
+        dao.newTask({ title: 'task2', courseId: 4 });
+        dao.newTask({ title: 'task3', courseId: 55 });
+        dao.newTask({ title: 'task4', courseId: 5 });
+        dao.newTask({ title: 'task5', courseId: 59 });
+        dao.newTask({ title: 'task6', courseId: 3, completed: true });
+        dao.newTask({ title: 'task7', courseId: 3 });
+        dao.newTask({ title: 'task8', courseId: 3 });
+        dao.newTask({ title: 'task9', courseId: 3 });
 
-        let result = dao.find({ title: 'task4', course: 'CS5000' });
+        let result = dao.find({ title: 'task4', courseId: 5 });
         chai.assert.isArray(result);
         chai.assert.lengthOf(result, 1);
 
-        result = dao.find({ course: 'CS3000', completed: true });
+        result = dao.find({ courseId: 3, completed: true });
         chai.assert.isArray(result);
         chai.assert.lengthOf(result, 1);
 
-        result = dao.find({ course: 'CS3000', completed: false });
+        result = dao.find({ courseId: 3, completed: false });
         chai.assert.isArray(result);
         chai.assert.lengthOf(result, 3);
 
@@ -160,30 +160,30 @@ describe('In-Memory TaskDAO', () => {
       });
       it('returns an empty array if no tasks exactly match all the criteria', () => {
         const dao = new TaskMemoryDAO();
-        dao.newTask({ title: 'task1', course: 'CS5000', completed: true });
-        dao.newTask({ title: 'task2', course: 'CS4000' });
-        dao.newTask({ title: 'task3', course: 'CS5555' });
-        dao.newTask({ title: 'task4', course: 'CS5000' });
-        dao.newTask({ title: 'task5', course: 'CS5980' });
-        dao.newTask({ title: 'task6', course: 'CS3000' });
+        dao.newTask({ title: 'task1', courseId: 5, completed: true });
+        dao.newTask({ title: 'task2', courseId: 4 });
+        dao.newTask({ title: 'task3', courseId: 55 });
+        dao.newTask({ title: 'task4', courseId: 5 });
+        dao.newTask({ title: 'task5', courseId: 59 });
+        dao.newTask({ title: 'task6', courseId: 3 });
 
         let result = dao.find({ title: 'task8' });
         chai.assert.isArray(result);
         chai.assert.isEmpty(result);
 
-        result = dao.find({ title: 'task1', course: 'CS4040' });
+        result = dao.find({ title: 'task1', courseId: 40 });
         chai.assert.isArray(result);
         chai.assert.isEmpty(result);
 
-        result = dao.find({ title: 'task1', course: 'CS5000', completed: false });
+        result = dao.find({ title: 'task1', courseId: 5, completed: false });
         chai.assert.isArray(result);
         chai.assert.isEmpty(result);
 
-        result = dao.find({ course: 'MS5000' });
+        result = dao.find({ courseId: 500 });
         chai.assert.isArray(result);
         chai.assert.isEmpty(result);
 
-        result = dao.find({ course: 'CS4000', completed: true });
+        result = dao.find({ courseId: 4, completed: true });
         chai.assert.isArray(result);
         chai.assert.isEmpty(result);
       });
@@ -192,17 +192,17 @@ describe('In-Memory TaskDAO', () => {
       it('returns a task with the given id if it exists in the tasks array', () => {
         const dao = new TaskMemoryDAO();
 
-        let newTask = dao.newTask({ title: 'some task', course: 'CS1111' });
+        let newTask = dao.newTask({ title: 'some task', courseId: 1 });
         let resultTask = dao.findById(newTask.id);
         chai.expect(resultTask).to.be.ok;
         chai.expect(resultTask).to.be.deep.equal(resultTask);
 
-        newTask = dao.newTask({ title: 'some task2', course: 'CS2222' });
+        newTask = dao.newTask({ title: 'some task2', courseId: 2 });
         resultTask = dao.findById(newTask.id);
         chai.expect(resultTask).to.be.ok;
         chai.expect(resultTask).to.be.deep.equal(resultTask);
 
-        newTask = dao.newTask({ title: 'some task3', course: 'CS3333' });
+        newTask = dao.newTask({ title: 'some task3', courseId: 3 });
         resultTask = dao.findById(newTask.id);
         chai.expect(resultTask).to.be.ok;
         chai.expect(resultTask).to.be.deep.equal(resultTask);
@@ -216,10 +216,10 @@ describe('In-Memory TaskDAO', () => {
         chai.expect(dao.findById(1)).to.not.be.ok;
 
         // with tasks added to tasks array
-        dao.newTask({ title: 't1', course: 'C1' });
-        dao.newTask({ title: 't2', course: 'C2' });
-        dao.newTask({ title: 't3', course: 'C3' });
-        dao.newTask({ title: 't4', course: 'C4' });
+        dao.newTask({ title: 't1', courseId: 1 });
+        dao.newTask({ title: 't2', courseId: 2 });
+        dao.newTask({ title: 't3', courseId: 3 });
+        dao.newTask({ title: 't4', courseId: 4 });
 
         chai.expect(dao.findById(dao.maxId + 5)).to.not.be.ok;
       });
@@ -229,11 +229,11 @@ describe('In-Memory TaskDAO', () => {
     it('should update the provided task properties when a task with the given id exists', () => {
       const dao = new TaskMemoryDAO();
 
-      let newTask = dao.newTask({ title: 'some task', course: 'CS1111' });
+      let newTask = dao.newTask({ title: 'some task', courseId: 1 });
       let props = {
         id: newTask.id,
         title: 'new title',
-        course: 'new course',
+        courseId: 2,
         completed: true,
         deadline: 'December 20, 2020',
       };
@@ -241,32 +241,32 @@ describe('In-Memory TaskDAO', () => {
       chai.assert.isOk(updatedTask);
       chai.assert.strictEqual(updatedTask.id, props.id);
       chai.assert.strictEqual(updatedTask.title, 'new title');
-      chai.assert.strictEqual(updatedTask.course, 'new course');
+      chai.assert.strictEqual(updatedTask.courseId, 2);
       chai.assert.isTrue(updatedTask.completed);
       chai.assert.strictEqual(updatedTask.deadline, 'December 20, 2020');
 
-      newTask = dao.newTask({ title: 'some task 2', course: 'CS2222' });
+      newTask = dao.newTask({ title: 'some task 2', courseId: 2 });
       props = { id: newTask.id, title: 'new title 2' };
       updatedTask = dao.updateTask(props);
       chai.assert.isOk(updatedTask);
       chai.assert.strictEqual(updatedTask.id, props.id);
       chai.assert.strictEqual(updatedTask.title, 'new title 2');
 
-      newTask = dao.newTask({ title: 'some task 3', course: 'CS3333' });
-      props = { id: newTask.id, course: 'new course id' };
+      newTask = dao.newTask({ title: 'some task 3', courseId: 3 });
+      props = { id: newTask.id, courseId: 4 };
       updatedTask = dao.updateTask(props);
       chai.assert.isOk(updatedTask);
       chai.assert.strictEqual(updatedTask.id, props.id);
-      chai.assert.strictEqual(updatedTask.course, 'new course id');
+      chai.assert.strictEqual(updatedTask.courseId, 4);
     });
     it('should not change properties that are not provided in props object', () => {
       const dao = new TaskMemoryDAO();
 
-      let newTask = dao.newTask({ title: 'some task', course: 'CS1111' });
+      let newTask = dao.newTask({ title: 'some task', courseId: 1 });
       let expected = {
         id: newTask.id,
         title: 'new title',
-        course: newTask.course,
+        courseId: newTask.courseId,
         completed: newTask.completed,
         deadline: newTask.deadline,
         scheduledDate: newTask.scheduledDate,
@@ -275,55 +275,55 @@ describe('In-Memory TaskDAO', () => {
       chai.assert.isOk(updatedTask);
       chai.assert.strictEqual(updatedTask.id, expected.id);
       chai.assert.strictEqual(updatedTask.title, expected.title);
-      chai.assert.strictEqual(updatedTask.course, expected.course);
+      chai.assert.strictEqual(updatedTask.courseId, expected.courseId);
       chai.assert.strictEqual(updatedTask.completed, expected.completed);
       chai.assert.strictEqual(updatedTask.deadline, expected.deadline);
 
-      newTask = dao.newTask({ title: 'some task 2', course: 'CS2222' });
+      newTask = dao.newTask({ title: 'some task 2', courseId: 2 });
       expected = {
         id: newTask.id,
         title: newTask.title,
-        course: 'CS5000',
+        courseId: 5,
         completed: newTask.completed,
         deadline: newTask.deadline,
         scheduledDate: newTask.scheduledDate,
       };
-      updatedTask = dao.updateTask({ id: newTask.id, course: 'CS5000' });
+      updatedTask = dao.updateTask({ id: newTask.id, courseId: 5 });
       chai.assert.isOk(updatedTask);
       chai.assert.strictEqual(updatedTask.id, expected.id);
       chai.assert.strictEqual(updatedTask.title, expected.title);
-      chai.assert.strictEqual(updatedTask.course, expected.course);
+      chai.assert.strictEqual(updatedTask.courseId, expected.courseId);
       chai.assert.strictEqual(updatedTask.completed, expected.completed);
       chai.assert.strictEqual(updatedTask.deadline, expected.deadline);
     });
     it('should return falsy value if props object parameter is not valid (non existent, empty, or no id)', () => {
       const dao = new TaskMemoryDAO();
-      const propsNoId = { title: 'new title', course: 'new course', completed: true };
+      const propsNoId = { title: 'new title', courseId: 'new course', completed: true };
       const nonExistentId = 5555;
       chai.assert.isNotOk(dao.updateTask());
       chai.assert.isNotOk(dao.updateTask({}));
       chai.assert.isNotOk(dao.updateTask(propsNoId));
-      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, course: 'new course' }));
+      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 'new course' }));
 
-      dao.newTask({ title: 'test task1', course: 'TEST1234' });
-      dao.newTask({ title: 'test task2', course: 'TEST1234' });
-      dao.newTask({ title: 'test task3', course: 'TEST1234' });
-      dao.newTask({ title: 'test task4', course: 'TEST1234' });
-      dao.newTask({ title: 'test task5', course: 'TEST1234' });
+      dao.newTask({ title: 'test task1', courseId: 1 });
+      dao.newTask({ title: 'test task2', courseId: 1 });
+      dao.newTask({ title: 'test task3', courseId: 1 });
+      dao.newTask({ title: 'test task4', courseId: 1 });
+      dao.newTask({ title: 'test task5', courseId: 1 });
 
       chai.assert.isNotOk(dao.updateTask());
       chai.assert.isNotOk(dao.updateTask({}));
       chai.assert.isNotOk(dao.updateTask(propsNoId));
-      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, course: 'new course' }));
+      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 2 }));
     });
   });
   describe('deleteById()', () => {
     it('should delete the task with the given id from dao.tasks', () => {
       const dao = new TaskMemoryDAO();
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      const deleteId = dao.newTask({ title: 'task to delete', course: 'TEST1234' }).id;
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      const deleteId = dao.newTask({ title: 'task to delete', courseId: 1 }).id;
       chai.assert.lengthOf(dao.tasks, 4);
 
       dao.deleteById(deleteId);
@@ -334,9 +334,9 @@ describe('In-Memory TaskDAO', () => {
     });
     it('should not delete any tasks if a task with the given id does not exist', () => {
       const dao = new TaskMemoryDAO();
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
       chai.assert.lengthOf(dao.tasks, 3);
       const nonExistentId = 5555;
 
@@ -345,16 +345,16 @@ describe('In-Memory TaskDAO', () => {
     });
     it('should return the deleted task', () => {
       const dao = new TaskMemoryDAO();
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      dao.newTask({ title: 'task 1', course: 'TEST1234' });
-      const deleteId = dao.newTask({ title: 'task to delete', course: 'TEST1234' }).id;
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      dao.newTask({ title: 'task 1', courseId: 1 });
+      const deleteId = dao.newTask({ title: 'task to delete', courseId: 1 }).id;
 
       const deletedTask = dao.deleteById(deleteId);
       chai.assert.isOk(deletedTask);
       chai.assert.strictEqual(deletedTask.id, deleteId);
       chai.assert.strictEqual(deletedTask.title, 'task to delete');
-      chai.assert.strictEqual(deletedTask.course, 'TEST1234');
+      chai.assert.strictEqual(deletedTask.courseId, 1);
     });
     it('should return falsy value if no task with the given id is found', () => {
       const dao = new TaskMemoryDAO();

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -5,7 +5,7 @@
 
 const chai = require('chai');
 
-const should = chai.should();
+const { assert, expect } = chai;
 const TaskMemoryDAO = require('./TaskMemoryDAO');
 const InMemoryDataStore = require('./InMemoryDataStore');
 
@@ -13,12 +13,12 @@ describe('In-Memory TaskDAO', () => {
   describe('constructor()', () => {
     it('should have access to the in-memory data store', () => {
       const dao = new TaskMemoryDAO();
-      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.be.equal(InMemoryDataStore);
     });
 
     it('should not be influenced by params', () => {
       const dao = new TaskMemoryDAO(8, 'some string', false);
-      chai.expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.be.equal(InMemoryDataStore);
     });
   });
 
@@ -34,34 +34,34 @@ describe('In-Memory TaskDAO', () => {
     });
 
     it('should result in falsy if Task creation is unsuccessful (no props obj, or no title/course)', () => {
-      chai.assert.isNotOk(dao.newTask());
-      chai.assert.isNotOk(dao.newTask(null));
-      chai.assert.isNotOk(dao.newTask(undefined));
-      chai.assert.isNotOk(dao.newTask({}));
-      chai.assert.isNotOk(dao.newTask(12));
-      chai.assert.isNotOk(dao.newTask(title = 'something', courseId = 1)); // param is not an object
+      assert.isNotOk(dao.newTask());
+      assert.isNotOk(dao.newTask(null));
+      assert.isNotOk(dao.newTask(undefined));
+      assert.isNotOk(dao.newTask({}));
+      assert.isNotOk(dao.newTask(12));
+      assert.isNotOk(dao.newTask(title = 'something', courseId = 1)); // param is not an object
 
-      chai.assert.isNotOk(dao.newTask({ title: 'some task' }));
-      chai.assert.isNotOk(dao.newTask({ courseId: 7 }));
-      chai.assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
-      chai.assert.isNotOk(dao.newTask({ courseId: 1, otherProp: 'some other property' }));
-      chai.assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
+      assert.isNotOk(dao.newTask({ title: 'some task' }));
+      assert.isNotOk(dao.newTask({ courseId: 7 }));
+      assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
+      assert.isNotOk(dao.newTask({ courseId: 1, otherProp: 'some other property' }));
+      assert.isNotOk(dao.newTask({ title: 'some task', otherProp: 'some other property' }));
     });
 
     it('should return a successfully created task', () => {
       const task = dao.newTask({ title: 'my task', courseId: 5 });
-      chai.assert.isOk(task);
-      chai.assert.strictEqual(task.title, 'my task');
-      chai.assert.strictEqual(task.courseId, 5);
+      assert.isOk(task);
+      assert.strictEqual(task.title, 'my task');
+      assert.strictEqual(task.courseId, 5);
     });
 
     it('should set default values for non-required properties', () => {
       const task = dao.newTask({ title: 'my task', courseId: 5 });
-      chai.assert.isOk(task);
-      chai.assert.isNumber(task.id);
-      chai.assert.isNull(task.deadline);
-      chai.assert.isFalse(task.completed);
-      chai.assert.isNull(task.scheduledDate);
+      assert.isOk(task);
+      assert.isNumber(task.id);
+      assert.isNull(task.deadline);
+      assert.isFalse(task.completed);
+      assert.isNull(task.scheduledDate);
     });
 
     it('should set all provided properties', () => {
@@ -73,28 +73,28 @@ describe('In-Memory TaskDAO', () => {
         scheduledDate: 'Jan 1, 2020',
       };
       const task = dao.newTask(props);
-      chai.assert.strictEqual(task.title, 'my task');
-      chai.assert.strictEqual(task.courseId, 5);
-      chai.assert.strictEqual(task.deadline, 'Jan 4, 2020');
-      chai.assert.isTrue(task.completed);
-      chai.assert.strictEqual(task.scheduledDate, 'Jan 1, 2020');
+      assert.strictEqual(task.title, 'my task');
+      assert.strictEqual(task.courseId, 5);
+      assert.strictEqual(task.deadline, 'Jan 4, 2020');
+      assert.isTrue(task.completed);
+      assert.strictEqual(task.scheduledDate, 'Jan 1, 2020');
     });
 
     it('should add the new task to the tasks array', () => {
       dao.newTask({ title: 'my task', courseId: 10 });
-      chai.assert.lengthOf(dao.data.tasks, 1);
-      chai.assert.strictEqual(dao.data.tasks[0].title, 'my task');
-      chai.assert.strictEqual(dao.data.tasks[0].courseId, 10);
+      assert.lengthOf(dao.data.tasks, 1);
+      assert.strictEqual(dao.data.tasks[0].title, 'my task');
+      assert.strictEqual(dao.data.tasks[0].courseId, 10);
 
       dao.newTask({ title: 'my task2', courseId: 3 });
-      chai.assert.lengthOf(dao.data.tasks, 2);
-      chai.assert.strictEqual(dao.data.tasks[1].title, 'my task2');
-      chai.assert.strictEqual(dao.data.tasks[1].courseId, 3);
+      assert.lengthOf(dao.data.tasks, 2);
+      assert.strictEqual(dao.data.tasks[1].title, 'my task2');
+      assert.strictEqual(dao.data.tasks[1].courseId, 3);
 
       dao.newTask({ title: 'my task3', courseId: 6 });
-      chai.assert.lengthOf(dao.data.tasks, 3);
-      chai.assert.strictEqual(dao.data.tasks[2].title, 'my task3');
-      chai.assert.strictEqual(dao.data.tasks[2].courseId, 6);
+      assert.lengthOf(dao.data.tasks, 3);
+      assert.strictEqual(dao.data.tasks[2].title, 'my task3');
+      assert.strictEqual(dao.data.tasks[2].courseId, 6);
     });
   });
 
@@ -114,9 +114,9 @@ describe('In-Memory TaskDAO', () => {
         for (let i = 1; i <= 10; i++) {
           dao.newTask({ title: `some task ${i}`, courseId: i });
         }
-        chai.assert.lengthOf(dao.find(), 10);
-        chai.assert.lengthOf(dao.find({}), 10);
-        chai.assert.lengthOf(dao.find(null), 10);
+        assert.lengthOf(dao.find(), 10);
+        assert.lengthOf(dao.find({}), 10);
+        assert.lengthOf(dao.find(null), 10);
       });
       it('returns an array of all tasks that exactly match single-attribute criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
@@ -127,20 +127,20 @@ describe('In-Memory TaskDAO', () => {
         dao.newTask({ title: 'task6', courseId: 3 });
 
         let result = dao.find({ title: 'task4' });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 1);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
 
         result = dao.find({ courseId: 5 });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 2);
+        assert.isArray(result);
+        assert.lengthOf(result, 2);
 
         result = dao.find({ completed: true });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 1);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
 
         result = dao.find({ completed: false });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 5);
+        assert.isArray(result);
+        assert.lengthOf(result, 5);
       });
       it('returns an array of all tasks that exactly match multi-attribute criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
@@ -154,20 +154,20 @@ describe('In-Memory TaskDAO', () => {
         dao.newTask({ title: 'task9', courseId: 3 });
 
         let result = dao.find({ title: 'task4', courseId: 5 });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 1);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
 
         result = dao.find({ courseId: 3, completed: true });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 1);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
 
         result = dao.find({ courseId: 3, completed: false });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 3);
+        assert.isArray(result);
+        assert.lengthOf(result, 3);
 
         result = dao.find({ title: 'task9', completed: false });
-        chai.assert.isArray(result);
-        chai.assert.lengthOf(result, 1);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
       });
       it('returns an empty array if no tasks exactly match all the criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
@@ -178,24 +178,24 @@ describe('In-Memory TaskDAO', () => {
         dao.newTask({ title: 'task6', courseId: 3 });
 
         let result = dao.find({ title: 'task8' });
-        chai.assert.isArray(result);
-        chai.assert.isEmpty(result);
+        assert.isArray(result);
+        assert.isEmpty(result);
 
         result = dao.find({ title: 'task1', courseId: 40 });
-        chai.assert.isArray(result);
-        chai.assert.isEmpty(result);
+        assert.isArray(result);
+        assert.isEmpty(result);
 
         result = dao.find({ title: 'task1', courseId: 5, completed: false });
-        chai.assert.isArray(result);
-        chai.assert.isEmpty(result);
+        assert.isArray(result);
+        assert.isEmpty(result);
 
         result = dao.find({ courseId: 500 });
-        chai.assert.isArray(result);
-        chai.assert.isEmpty(result);
+        assert.isArray(result);
+        assert.isEmpty(result);
 
         result = dao.find({ courseId: 4, completed: true });
-        chai.assert.isArray(result);
-        chai.assert.isEmpty(result);
+        assert.isArray(result);
+        assert.isEmpty(result);
       });
     });
     describe('findById()', () => {
@@ -212,24 +212,24 @@ describe('In-Memory TaskDAO', () => {
       it('returns a task with the given id if it exists in the tasks array', () => {
         let newTask = dao.newTask({ title: 'some task', courseId: 1 });
         let resultTask = dao.findById(newTask.id);
-        chai.expect(resultTask).to.be.ok;
-        chai.expect(resultTask).to.be.deep.equal(resultTask);
+        expect(resultTask).to.be.ok;
+        expect(resultTask).to.be.deep.equal(resultTask);
 
         newTask = dao.newTask({ title: 'some task2', courseId: 2 });
         resultTask = dao.findById(newTask.id);
-        chai.expect(resultTask).to.be.ok;
-        chai.expect(resultTask).to.be.deep.equal(resultTask);
+        expect(resultTask).to.be.ok;
+        expect(resultTask).to.be.deep.equal(resultTask);
 
         newTask = dao.newTask({ title: 'some task3', courseId: 3 });
         resultTask = dao.findById(newTask.id);
-        chai.expect(resultTask).to.be.ok;
-        chai.expect(resultTask).to.be.deep.equal(resultTask);
+        expect(resultTask).to.be.ok;
+        expect(resultTask).to.be.deep.equal(resultTask);
       });
       it('returns falsy value if a task with the given id does not exist in the tasks array', () => {
         // no tasks added yet
-        chai.expect(dao.findById(50)).to.not.be.ok;
-        chai.expect(dao.findById(0)).to.not.be.ok;
-        chai.expect(dao.findById(1)).to.not.be.ok;
+        expect(dao.findById(50)).to.not.be.ok;
+        expect(dao.findById(0)).to.not.be.ok;
+        expect(dao.findById(1)).to.not.be.ok;
 
         // with tasks added to tasks array
         dao.newTask({ title: 't1', courseId: 1 });
@@ -237,7 +237,7 @@ describe('In-Memory TaskDAO', () => {
         dao.newTask({ title: 't3', courseId: 3 });
         dao.newTask({ title: 't4', courseId: 4 });
 
-        chai.expect(dao.findById(dao.maxId + 5)).to.not.be.ok;
+        expect(dao.findById(dao.maxId + 5)).to.not.be.ok;
       });
     });
   });
@@ -262,26 +262,26 @@ describe('In-Memory TaskDAO', () => {
         deadline: 'December 20, 2020',
       };
       let updatedTask = dao.updateTask(props);
-      chai.assert.isOk(updatedTask);
-      chai.assert.strictEqual(updatedTask.id, props.id);
-      chai.assert.strictEqual(updatedTask.title, 'new title');
-      chai.assert.strictEqual(updatedTask.courseId, 2);
-      chai.assert.isTrue(updatedTask.completed);
-      chai.assert.strictEqual(updatedTask.deadline, 'December 20, 2020');
+      assert.isOk(updatedTask);
+      assert.strictEqual(updatedTask.id, props.id);
+      assert.strictEqual(updatedTask.title, 'new title');
+      assert.strictEqual(updatedTask.courseId, 2);
+      assert.isTrue(updatedTask.completed);
+      assert.strictEqual(updatedTask.deadline, 'December 20, 2020');
 
       newTask = dao.newTask({ title: 'some task 2', courseId: 2 });
       props = { id: newTask.id, title: 'new title 2' };
       updatedTask = dao.updateTask(props);
-      chai.assert.isOk(updatedTask);
-      chai.assert.strictEqual(updatedTask.id, props.id);
-      chai.assert.strictEqual(updatedTask.title, 'new title 2');
+      assert.isOk(updatedTask);
+      assert.strictEqual(updatedTask.id, props.id);
+      assert.strictEqual(updatedTask.title, 'new title 2');
 
       newTask = dao.newTask({ title: 'some task 3', courseId: 3 });
       props = { id: newTask.id, courseId: 4 };
       updatedTask = dao.updateTask(props);
-      chai.assert.isOk(updatedTask);
-      chai.assert.strictEqual(updatedTask.id, props.id);
-      chai.assert.strictEqual(updatedTask.courseId, 4);
+      assert.isOk(updatedTask);
+      assert.strictEqual(updatedTask.id, props.id);
+      assert.strictEqual(updatedTask.courseId, 4);
     });
     it('should not change properties that are not provided in props object', () => {
       let newTask = dao.newTask({ title: 'some task', courseId: 1 });
@@ -294,12 +294,12 @@ describe('In-Memory TaskDAO', () => {
         scheduledDate: newTask.scheduledDate,
       };
       let updatedTask = dao.updateTask({ id: newTask.id, title: 'new title' });
-      chai.assert.isOk(updatedTask);
-      chai.assert.strictEqual(updatedTask.id, expected.id);
-      chai.assert.strictEqual(updatedTask.title, expected.title);
-      chai.assert.strictEqual(updatedTask.courseId, expected.courseId);
-      chai.assert.strictEqual(updatedTask.completed, expected.completed);
-      chai.assert.strictEqual(updatedTask.deadline, expected.deadline);
+      assert.isOk(updatedTask);
+      assert.strictEqual(updatedTask.id, expected.id);
+      assert.strictEqual(updatedTask.title, expected.title);
+      assert.strictEqual(updatedTask.courseId, expected.courseId);
+      assert.strictEqual(updatedTask.completed, expected.completed);
+      assert.strictEqual(updatedTask.deadline, expected.deadline);
 
       newTask = dao.newTask({ title: 'some task 2', courseId: 2 });
       expected = {
@@ -311,20 +311,20 @@ describe('In-Memory TaskDAO', () => {
         scheduledDate: newTask.scheduledDate,
       };
       updatedTask = dao.updateTask({ id: newTask.id, courseId: 5 });
-      chai.assert.isOk(updatedTask);
-      chai.assert.strictEqual(updatedTask.id, expected.id);
-      chai.assert.strictEqual(updatedTask.title, expected.title);
-      chai.assert.strictEqual(updatedTask.courseId, expected.courseId);
-      chai.assert.strictEqual(updatedTask.completed, expected.completed);
-      chai.assert.strictEqual(updatedTask.deadline, expected.deadline);
+      assert.isOk(updatedTask);
+      assert.strictEqual(updatedTask.id, expected.id);
+      assert.strictEqual(updatedTask.title, expected.title);
+      assert.strictEqual(updatedTask.courseId, expected.courseId);
+      assert.strictEqual(updatedTask.completed, expected.completed);
+      assert.strictEqual(updatedTask.deadline, expected.deadline);
     });
     it('should return falsy value if props object parameter is not valid (non existent, empty, or no id)', () => {
       const propsNoId = { title: 'new title', courseId: 'new course', completed: true };
       const nonExistentId = 5555;
-      chai.assert.isNotOk(dao.updateTask());
-      chai.assert.isNotOk(dao.updateTask({}));
-      chai.assert.isNotOk(dao.updateTask(propsNoId));
-      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 'new course' }));
+      assert.isNotOk(dao.updateTask());
+      assert.isNotOk(dao.updateTask({}));
+      assert.isNotOk(dao.updateTask(propsNoId));
+      assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 'new course' }));
 
       dao.newTask({ title: 'test task1', courseId: 1 });
       dao.newTask({ title: 'test task2', courseId: 1 });
@@ -332,10 +332,10 @@ describe('In-Memory TaskDAO', () => {
       dao.newTask({ title: 'test task4', courseId: 1 });
       dao.newTask({ title: 'test task5', courseId: 1 });
 
-      chai.assert.isNotOk(dao.updateTask());
-      chai.assert.isNotOk(dao.updateTask({}));
-      chai.assert.isNotOk(dao.updateTask(propsNoId));
-      chai.assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 2 }));
+      assert.isNotOk(dao.updateTask());
+      assert.isNotOk(dao.updateTask({}));
+      assert.isNotOk(dao.updateTask(propsNoId));
+      assert.isNotOk(dao.updateTask({ id: nonExistentId, courseId: 2 }));
     });
   });
   describe('deleteById()', () => {
@@ -354,23 +354,23 @@ describe('In-Memory TaskDAO', () => {
       dao.newTask({ title: 'task 1', courseId: 1 });
       dao.newTask({ title: 'task 1', courseId: 1 });
       const deleteId = dao.newTask({ title: 'task to delete', courseId: 1 }).id;
-      chai.assert.lengthOf(dao.data.tasks, 4);
+      assert.lengthOf(dao.data.tasks, 4);
 
       dao.deleteById(deleteId);
-      chai.assert.lengthOf(dao.data.tasks, 3);
+      assert.lengthOf(dao.data.tasks, 3);
 
       const stillExists = dao.data.tasks.reduce((res, task) => res || (task.id === deleteId), false);
-      chai.assert.isFalse(stillExists, 'A task with the deleteId still exists in the tasks array');
+      assert.isFalse(stillExists, 'A task with the deleteId still exists in the tasks array');
     });
     it('should not delete any tasks if a task with the given id does not exist', () => {
       dao.newTask({ title: 'task 1', courseId: 1 });
       dao.newTask({ title: 'task 1', courseId: 1 });
       dao.newTask({ title: 'task 1', courseId: 1 });
-      chai.assert.lengthOf(dao.data.tasks, 3);
+      assert.lengthOf(dao.data.tasks, 3);
       const nonExistentId = 5555;
 
       dao.deleteById(nonExistentId);
-      chai.assert.lengthOf(dao.data.tasks, 3);
+      assert.lengthOf(dao.data.tasks, 3);
     });
     it('should return the deleted task', () => {
       dao.newTask({ title: 'task 1', courseId: 1 });
@@ -379,14 +379,14 @@ describe('In-Memory TaskDAO', () => {
       const deleteId = dao.newTask({ title: 'task to delete', courseId: 1 }).id;
 
       const deletedTask = dao.deleteById(deleteId);
-      chai.assert.isOk(deletedTask);
-      chai.assert.strictEqual(deletedTask.id, deleteId);
-      chai.assert.strictEqual(deletedTask.title, 'task to delete');
-      chai.assert.strictEqual(deletedTask.courseId, 1);
+      assert.isOk(deletedTask);
+      assert.strictEqual(deletedTask.id, deleteId);
+      assert.strictEqual(deletedTask.title, 'task to delete');
+      assert.strictEqual(deletedTask.courseId, 1);
     });
     it('should return falsy value if no task with the given id is found', () => {
-      chai.assert.isNotOk(dao.deleteById());
-      chai.assert.isNotOk(dao.deleteById(5555));
+      assert.isNotOk(dao.deleteById());
+      assert.isNotOk(dao.deleteById(5555));
     });
   });
 });

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -28,7 +28,7 @@ describe('In-Memory TaskDAO', () => {
   });
 
   describe('newTask()', () => {
-    it('should result in null if Task creation is unsuccessful (no props obj, or no title/course)', () => {
+    it('should result in falsy if Task creation is unsuccessful (no props obj, or no title/course)', () => {
       const dao = new TaskMemoryDAO();
       chai.assert.isNotOk(dao.newTask());
       chai.assert.isNotOk(dao.newTask(null));

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -21,7 +21,6 @@ describe('In-Memory TaskDAO', () => {
     let dao;
     beforeEach(() => {
       dao = new TaskMemoryDAO();
-      dao.data.clear();
     });
 
     afterEach(() => {
@@ -99,7 +98,6 @@ describe('In-Memory TaskDAO', () => {
 
       beforeEach(() => {
         dao = new TaskMemoryDAO();
-        dao.data.clear();
       });
 
       afterEach(() => {
@@ -202,7 +200,6 @@ describe('In-Memory TaskDAO', () => {
       let dao;
       beforeEach(() => {
         dao = new TaskMemoryDAO();
-        dao.data.clear();
       });
 
       afterEach(() => {
@@ -248,7 +245,6 @@ describe('In-Memory TaskDAO', () => {
 
     beforeEach(() => {
       dao = new TaskMemoryDAO();
-      dao.data.clear();
     });
 
     afterEach(() => {
@@ -348,7 +344,6 @@ describe('In-Memory TaskDAO', () => {
 
     beforeEach(() => {
       dao = new TaskMemoryDAO();
-      dao.data.clear();
     });
 
     afterEach(() => {

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -1,8 +1,3 @@
-/* eslint-disable no-unused-expressions */
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const { assert, expect } = chai;

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -13,12 +13,12 @@ describe('In-Memory TaskDAO', () => {
   describe('constructor()', () => {
     it('should have access to the in-memory data store', () => {
       const dao = new TaskMemoryDAO();
-      expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.deep.equal(InMemoryDataStore);
     });
 
     it('should not be influenced by params', () => {
       const dao = new TaskMemoryDAO(8, 'some string', false);
-      expect(dao.data).to.be.equal(InMemoryDataStore);
+      expect(dao.data).to.deep.equal(InMemoryDataStore);
     });
   });
 

--- a/data/TaskMemoryDAO.test.js
+++ b/data/TaskMemoryDAO.test.js
@@ -96,6 +96,7 @@ describe('In-Memory TaskDAO', () => {
   describe('Querying', () => {
     describe('find()', () => {
       let dao;
+
       beforeEach(() => {
         dao = new TaskMemoryDAO();
         dao.data.clear();
@@ -113,6 +114,7 @@ describe('In-Memory TaskDAO', () => {
         assert.lengthOf(dao.find({}), 10);
         assert.lengthOf(dao.find(null), 10);
       });
+
       it('returns an array of all tasks that exactly match single-attribute criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
         dao.newTask({ title: 'task2', courseId: 4 });
@@ -137,6 +139,7 @@ describe('In-Memory TaskDAO', () => {
         assert.isArray(result);
         assert.lengthOf(result, 5);
       });
+
       it('returns an array of all tasks that exactly match multi-attribute criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
         dao.newTask({ title: 'task2', courseId: 4 });
@@ -164,6 +167,7 @@ describe('In-Memory TaskDAO', () => {
         assert.isArray(result);
         assert.lengthOf(result, 1);
       });
+
       it('returns an empty array if no tasks exactly match all the criteria', () => {
         dao.newTask({ title: 'task1', courseId: 5, completed: true });
         dao.newTask({ title: 'task2', courseId: 4 });
@@ -193,6 +197,7 @@ describe('In-Memory TaskDAO', () => {
         assert.isEmpty(result);
       });
     });
+
     describe('findById()', () => {
       let dao;
       beforeEach(() => {
@@ -220,6 +225,7 @@ describe('In-Memory TaskDAO', () => {
         expect(resultTask).to.be.ok;
         expect(resultTask).to.be.deep.equal(resultTask);
       });
+
       it('returns falsy value if a task with the given id does not exist in the tasks array', () => {
         // no tasks added yet
         expect(dao.findById(50)).to.not.be.ok;
@@ -236,8 +242,10 @@ describe('In-Memory TaskDAO', () => {
       });
     });
   });
+
   describe('updateTask()', () => {
     let dao;
+
     beforeEach(() => {
       dao = new TaskMemoryDAO();
       dao.data.clear();
@@ -278,6 +286,7 @@ describe('In-Memory TaskDAO', () => {
       assert.strictEqual(updatedTask.id, props.id);
       assert.strictEqual(updatedTask.courseId, 4);
     });
+
     it('should not change properties that are not provided in props object', () => {
       let newTask = dao.newTask({ title: 'some task', courseId: 1 });
       let expected = {
@@ -313,6 +322,7 @@ describe('In-Memory TaskDAO', () => {
       assert.strictEqual(updatedTask.completed, expected.completed);
       assert.strictEqual(updatedTask.deadline, expected.deadline);
     });
+
     it('should return falsy value if props object parameter is not valid (non existent, empty, or no id)', () => {
       const propsNoId = { title: 'new title', courseId: 'new course', completed: true };
       const nonExistentId = 5555;
@@ -335,6 +345,7 @@ describe('In-Memory TaskDAO', () => {
   });
   describe('deleteById()', () => {
     let dao;
+
     beforeEach(() => {
       dao = new TaskMemoryDAO();
       dao.data.clear();
@@ -357,6 +368,7 @@ describe('In-Memory TaskDAO', () => {
       const stillExists = dao.data.tasks.reduce((res, task) => res || (task.id === deleteId), false);
       assert.isFalse(stillExists, 'A task with the deleteId still exists in the tasks array');
     });
+
     it('should not delete any tasks if a task with the given id does not exist', () => {
       dao.newTask({ title: 'task 1', courseId: 1 });
       dao.newTask({ title: 'task 1', courseId: 1 });
@@ -367,6 +379,7 @@ describe('In-Memory TaskDAO', () => {
       dao.deleteById(nonExistentId);
       assert.lengthOf(dao.data.tasks, 3);
     });
+
     it('should return the deleted task', () => {
       dao.newTask({ title: 'task 1', courseId: 1 });
       dao.newTask({ title: 'task 1', courseId: 1 });
@@ -379,6 +392,7 @@ describe('In-Memory TaskDAO', () => {
       assert.strictEqual(deletedTask.title, 'task to delete');
       assert.strictEqual(deletedTask.courseId, 1);
     });
+
     it('should return falsy value if no task with the given id is found', () => {
       assert.isNotOk(dao.deleteById());
       assert.isNotOk(dao.deleteById(5555));

--- a/data/TaskRepository.js
+++ b/data/TaskRepository.js
@@ -15,8 +15,8 @@ class TaskRepository {
     return this.dao.updateTask(props);
   }
 
-  getByCourse(course) {
-    return this.dao.find({}).filter((task) => task.course === course);
+  getByCourseId(courseId) {
+    return this.dao.find({}).filter((task) => task.courseId === courseId);
   }
 
   newTask(props) {

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -10,7 +10,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {
@@ -40,7 +39,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {
@@ -76,7 +74,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {
@@ -120,7 +117,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {
@@ -169,7 +165,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {
@@ -204,7 +199,6 @@ describe('TaskRepository', () => {
 
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
-      repo.dao.data.clear();
     });
 
     afterEach(() => {

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const { assert } = chai;

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -7,6 +7,7 @@ const TaskRepository = require('./TaskRepository');
 describe('TaskRepository', () => {
   describe('getAll()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -22,6 +23,7 @@ describe('TaskRepository', () => {
       assert.lengthOf(result, 0);
       repo.newTask({ title: 'Task 1', courseId: 1 });
     });
+
     it('should return an array of all tasks', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -32,8 +34,10 @@ describe('TaskRepository', () => {
       assert.lengthOf(result, 4);
     });
   });
+
   describe('getById()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -42,6 +46,7 @@ describe('TaskRepository', () => {
     afterEach(() => {
       repo.dao.data.clear();
     });
+
     it('should return the task with the given id', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -52,6 +57,7 @@ describe('TaskRepository', () => {
       assert.strictEqual(result.title, 'Task 4');
       assert.strictEqual(result.courseId, 4);
     });
+
     it('should return falsy if a task with the given id does not exist', () => {
       assert.isNotOk(repo.getById());
       assert.isNotOk(repo.getById(10));
@@ -64,8 +70,10 @@ describe('TaskRepository', () => {
       assert.isNotOk(repo.getById({ id: 10 }));
     });
   });
+
   describe('update()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -74,6 +82,7 @@ describe('TaskRepository', () => {
     afterEach(() => {
       repo.dao.data.clear();
     });
+
     it('should return the updated task', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -83,6 +92,7 @@ describe('TaskRepository', () => {
       assert.isOk(result);
       assert.strictEqual(result.id, updateId);
     });
+
     it('should update any provided valid fields', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -94,7 +104,8 @@ describe('TaskRepository', () => {
       assert.strictEqual(result.title, 'new title');
       assert.strictEqual(result.courseId, 5);
     });
-    it('should return null if update is unsuccessful (no props object, no id field, task does not exist)', () => {
+
+    it('should return falsy if update is unsuccessful (no props object, no id field, task does not exist)', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -106,6 +117,7 @@ describe('TaskRepository', () => {
   });
   describe('getByCourseId()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -114,6 +126,7 @@ describe('TaskRepository', () => {
     afterEach(() => {
       repo.dao.data.clear();
     });
+
     it('should return an array of all tasks matching the provided course', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -130,6 +143,7 @@ describe('TaskRepository', () => {
       assert.isArray(result);
       assert.lengthOf(result, 3);
     });
+
     it('should return an empty array if no tasks match the course', () => {
       assert.isArray(repo.getByCourseId());
       assert.isEmpty(repo.getByCourseId());
@@ -149,8 +163,10 @@ describe('TaskRepository', () => {
       assert.isEmpty(repo.getByCourseId(777));
     });
   });
+
   describe('newTask()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -159,12 +175,14 @@ describe('TaskRepository', () => {
     afterEach(() => {
       repo.dao.data.clear();
     });
+
     it('should return the created task', () => {
       const result = repo.newTask({ title: 'new task', courseId: 1 });
       assert.isOk(result);
       assert.strictEqual(result.title, 'new task');
       assert.strictEqual(result.courseId, 1);
     });
+
     it('should add the new task to the DAO', () => {
       const newTask = repo.newTask({ title: 'new task', courseId: 1 });
       const result = repo.getById(newTask.id);
@@ -172,6 +190,7 @@ describe('TaskRepository', () => {
       assert.strictEqual(result.title, 'new task');
       assert.strictEqual(result.courseId, 1);
     });
+
     it('should return falsy if task creation is unsuccessful', () => {
       assert.isNotOk(repo.newTask());
       assert.isNotOk(repo.newTask({}));
@@ -179,8 +198,10 @@ describe('TaskRepository', () => {
       assert.isNotOk(repo.newTask({ courseId: 1 }));
     });
   });
+
   describe('deleteById()', () => {
     let repo;
+
     beforeEach(() => {
       repo = new TaskRepository(new TaskMemoryDAO());
       repo.dao.data.clear();
@@ -189,6 +210,7 @@ describe('TaskRepository', () => {
     afterEach(() => {
       repo.dao.data.clear();
     });
+
     it('should return the deleted task', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -200,6 +222,7 @@ describe('TaskRepository', () => {
       assert.strictEqual(result.title, 'Task 4');
       assert.strictEqual(result.courseId, 1);
     });
+
     it('should remove the task with the given id from the DAO', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -209,6 +232,7 @@ describe('TaskRepository', () => {
       const result = repo.deleteById(taskToDelete.id);
       assert.isNotOk(repo.getById(taskToDelete.id));
     });
+
     it('should return falsy if task deletion is unsuccessful (task not found, id not provided)', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -10,14 +10,23 @@ const TaskRepository = require('./TaskRepository');
 
 describe('TaskRepository', () => {
   describe('getAll()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
+
     it('should return an empty array if no tasks exist', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       const result = repo.getAll();
       chai.assert.isArray(result);
       chai.assert.lengthOf(result, 0);
+      repo.newTask({ title: 'Task 1', courseId: 1 });
     });
     it('should return an array of all tasks', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -28,8 +37,16 @@ describe('TaskRepository', () => {
     });
   });
   describe('getById()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
     it('should return the task with the given id', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -40,7 +57,6 @@ describe('TaskRepository', () => {
       chai.assert.strictEqual(result.courseId, 4);
     });
     it('should return falsy if a task with the given id does not exist', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       chai.assert.isNotOk(repo.getById());
       chai.assert.isNotOk(repo.getById(10));
       chai.assert.isNotOk(repo.getById({}));
@@ -53,8 +69,16 @@ describe('TaskRepository', () => {
     });
   });
   describe('update()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
     it('should return the updated task', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -64,7 +88,6 @@ describe('TaskRepository', () => {
       chai.assert.strictEqual(result.id, updateId);
     });
     it('should update any provided valid fields', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -76,7 +99,6 @@ describe('TaskRepository', () => {
       chai.assert.strictEqual(result.courseId, 5);
     });
     it('should return null if update is unsuccessful (no props object, no id field, task does not exist)', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -87,8 +109,16 @@ describe('TaskRepository', () => {
     });
   });
   describe('getByCourseId()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
     it('should return an array of all tasks matching the provided course', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -105,7 +135,6 @@ describe('TaskRepository', () => {
       chai.assert.lengthOf(result, 3);
     });
     it('should return an empty array if no tasks match the course', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       chai.assert.isArray(repo.getByCourseId());
       chai.assert.isEmpty(repo.getByCourseId());
       chai.assert.isArray(repo.getByCourseId(1));
@@ -125,15 +154,22 @@ describe('TaskRepository', () => {
     });
   });
   describe('newTask()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
     it('should return the created task', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       const result = repo.newTask({ title: 'new task', courseId: 1 });
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.title, 'new task');
       chai.assert.strictEqual(result.courseId, 1);
     });
     it('should add the new task to the DAO', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       const newTask = repo.newTask({ title: 'new task', courseId: 1 });
       const result = repo.getById(newTask.id);
       chai.assert.isOk(result);
@@ -141,7 +177,6 @@ describe('TaskRepository', () => {
       chai.assert.strictEqual(result.courseId, 1);
     });
     it('should return falsy if task creation is unsuccessful', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       chai.assert.isNotOk(repo.newTask());
       chai.assert.isNotOk(repo.newTask({}));
       chai.assert.isNotOk(repo.newTask({ title: 'new task' }));
@@ -149,8 +184,16 @@ describe('TaskRepository', () => {
     });
   });
   describe('deleteById()', () => {
+    let repo;
+    beforeEach(() => {
+      repo = new TaskRepository(new TaskMemoryDAO());
+      repo.dao.data.clear();
+    });
+
+    afterEach(() => {
+      repo.dao.data.clear();
+    });
     it('should return the deleted task', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -162,7 +205,6 @@ describe('TaskRepository', () => {
       chai.assert.strictEqual(result.courseId, 1);
     });
     it('should remove the task with the given id from the DAO', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
@@ -172,7 +214,6 @@ describe('TaskRepository', () => {
       chai.assert.isNotOk(repo.getById(taskToDelete.id));
     });
     it('should return falsy if task deletion is unsuccessful (task not found, id not provided)', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -4,7 +4,7 @@
 
 const chai = require('chai');
 
-const should = chai.should();
+const { assert } = chai;
 const TaskMemoryDAO = require('./TaskMemoryDAO');
 const TaskRepository = require('./TaskRepository');
 
@@ -22,8 +22,8 @@ describe('TaskRepository', () => {
 
     it('should return an empty array if no tasks exist', () => {
       const result = repo.getAll();
-      chai.assert.isArray(result);
-      chai.assert.lengthOf(result, 0);
+      assert.isArray(result);
+      assert.lengthOf(result, 0);
       repo.newTask({ title: 'Task 1', courseId: 1 });
     });
     it('should return an array of all tasks', () => {
@@ -32,8 +32,8 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 3', courseId: 1 });
       repo.newTask({ title: 'Task 4', courseId: 1 });
       const result = repo.getAll();
-      chai.assert.isArray(result);
-      chai.assert.lengthOf(result, 4);
+      assert.isArray(result);
+      assert.lengthOf(result, 4);
     });
   });
   describe('getById()', () => {
@@ -52,20 +52,20 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 3', courseId: 1 });
       const taskToFind = repo.newTask({ title: 'Task 4', courseId: 4 });
       const result = repo.getById(taskToFind.id);
-      chai.assert.isOk(result);
-      chai.assert.strictEqual(result.title, 'Task 4');
-      chai.assert.strictEqual(result.courseId, 4);
+      assert.isOk(result);
+      assert.strictEqual(result.title, 'Task 4');
+      assert.strictEqual(result.courseId, 4);
     });
     it('should return falsy if a task with the given id does not exist', () => {
-      chai.assert.isNotOk(repo.getById());
-      chai.assert.isNotOk(repo.getById(10));
-      chai.assert.isNotOk(repo.getById({}));
+      assert.isNotOk(repo.getById());
+      assert.isNotOk(repo.getById(10));
+      assert.isNotOk(repo.getById({}));
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
-      chai.assert.isNotOk(repo.getById());
-      chai.assert.isNotOk(repo.getById(9999));
-      chai.assert.isNotOk(repo.getById({ id: 10 }));
+      assert.isNotOk(repo.getById());
+      assert.isNotOk(repo.getById(9999));
+      assert.isNotOk(repo.getById({ id: 10 }));
     });
   });
   describe('update()', () => {
@@ -84,8 +84,8 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 3', courseId: 1 });
       const updateId = repo.newTask({ title: 'UPDATE ME', courseId: 4 }).id;
       const result = repo.update({ id: updateId, title: 'new title', courseId: 7 });
-      chai.assert.isOk(result);
-      chai.assert.strictEqual(result.id, updateId);
+      assert.isOk(result);
+      assert.strictEqual(result.id, updateId);
     });
     it('should update any provided valid fields', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
@@ -93,19 +93,19 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 3', courseId: 1 });
       const updateId = repo.newTask({ title: 'UPDATE ME', courseId: 4 }).id;
       const result = repo.update({ id: updateId, title: 'new title', courseId: 5 });
-      chai.assert.isOk(result);
-      chai.assert.strictEqual(result.id, updateId);
-      chai.assert.strictEqual(result.title, 'new title');
-      chai.assert.strictEqual(result.courseId, 5);
+      assert.isOk(result);
+      assert.strictEqual(result.id, updateId);
+      assert.strictEqual(result.title, 'new title');
+      assert.strictEqual(result.courseId, 5);
     });
     it('should return null if update is unsuccessful (no props object, no id field, task does not exist)', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
       repo.newTask({ title: 'Task 4', courseId: 1 });
-      chai.assert.isNotOk(repo.update());
-      chai.assert.isNotOk(repo.update({}));
-      chai.assert.isNotOk(repo.update({ id: 12345 }));
+      assert.isNotOk(repo.update());
+      assert.isNotOk(repo.update({}));
+      assert.isNotOk(repo.update({ id: 12345 }));
     });
   });
   describe('getByCourseId()', () => {
@@ -127,18 +127,18 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 2', courseId: 5 });
       repo.newTask({ title: 'Task 3', courseId: 5 });
       let result = repo.getByCourseId(1);
-      chai.assert.isArray(result);
-      chai.assert.lengthOf(result, 4);
+      assert.isArray(result);
+      assert.lengthOf(result, 4);
 
       result = repo.getByCourseId(5);
-      chai.assert.isArray(result);
-      chai.assert.lengthOf(result, 3);
+      assert.isArray(result);
+      assert.lengthOf(result, 3);
     });
     it('should return an empty array if no tasks match the course', () => {
-      chai.assert.isArray(repo.getByCourseId());
-      chai.assert.isEmpty(repo.getByCourseId());
-      chai.assert.isArray(repo.getByCourseId(1));
-      chai.assert.isEmpty(repo.getByCourseId(1));
+      assert.isArray(repo.getByCourseId());
+      assert.isEmpty(repo.getByCourseId());
+      assert.isArray(repo.getByCourseId(1));
+      assert.isEmpty(repo.getByCourseId(1));
 
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
@@ -147,10 +147,10 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 1', courseId: 5 });
       repo.newTask({ title: 'Task 2', courseId: 5 });
       repo.newTask({ title: 'Task 3', courseId: 5 });
-      chai.assert.isArray(repo.getByCourseId());
-      chai.assert.isEmpty(repo.getByCourseId());
-      chai.assert.isArray(repo.getByCourseId(777));
-      chai.assert.isEmpty(repo.getByCourseId(777));
+      assert.isArray(repo.getByCourseId());
+      assert.isEmpty(repo.getByCourseId());
+      assert.isArray(repo.getByCourseId(777));
+      assert.isEmpty(repo.getByCourseId(777));
     });
   });
   describe('newTask()', () => {
@@ -165,22 +165,22 @@ describe('TaskRepository', () => {
     });
     it('should return the created task', () => {
       const result = repo.newTask({ title: 'new task', courseId: 1 });
-      chai.assert.isOk(result);
-      chai.assert.strictEqual(result.title, 'new task');
-      chai.assert.strictEqual(result.courseId, 1);
+      assert.isOk(result);
+      assert.strictEqual(result.title, 'new task');
+      assert.strictEqual(result.courseId, 1);
     });
     it('should add the new task to the DAO', () => {
       const newTask = repo.newTask({ title: 'new task', courseId: 1 });
       const result = repo.getById(newTask.id);
-      chai.assert.isOk(result);
-      chai.assert.strictEqual(result.title, 'new task');
-      chai.assert.strictEqual(result.courseId, 1);
+      assert.isOk(result);
+      assert.strictEqual(result.title, 'new task');
+      assert.strictEqual(result.courseId, 1);
     });
     it('should return falsy if task creation is unsuccessful', () => {
-      chai.assert.isNotOk(repo.newTask());
-      chai.assert.isNotOk(repo.newTask({}));
-      chai.assert.isNotOk(repo.newTask({ title: 'new task' }));
-      chai.assert.isNotOk(repo.newTask({ courseId: 1 }));
+      assert.isNotOk(repo.newTask());
+      assert.isNotOk(repo.newTask({}));
+      assert.isNotOk(repo.newTask({ title: 'new task' }));
+      assert.isNotOk(repo.newTask({ courseId: 1 }));
     });
   });
   describe('deleteById()', () => {
@@ -199,27 +199,27 @@ describe('TaskRepository', () => {
       repo.newTask({ title: 'Task 3', courseId: 1 });
       const taskToDelete = repo.newTask({ title: 'Task 4', courseId: 1 });
       const result = repo.deleteById(taskToDelete.id);
-      chai.assert.isOk(result);
-      chai.assert.isObject(result);
-      chai.assert.strictEqual(result.title, 'Task 4');
-      chai.assert.strictEqual(result.courseId, 1);
+      assert.isOk(result);
+      assert.isObject(result);
+      assert.strictEqual(result.title, 'Task 4');
+      assert.strictEqual(result.courseId, 1);
     });
     it('should remove the task with the given id from the DAO', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
       const taskToDelete = repo.newTask({ title: 'Task 4', courseId: 1 });
-      chai.assert.isOk(repo.getById(taskToDelete.id));
+      assert.isOk(repo.getById(taskToDelete.id));
       const result = repo.deleteById(taskToDelete.id);
-      chai.assert.isNotOk(repo.getById(taskToDelete.id));
+      assert.isNotOk(repo.getById(taskToDelete.id));
     });
     it('should return falsy if task deletion is unsuccessful (task not found, id not provided)', () => {
       repo.newTask({ title: 'Task 1', courseId: 1 });
       repo.newTask({ title: 'Task 2', courseId: 1 });
       repo.newTask({ title: 'Task 3', courseId: 1 });
-      chai.assert.isNotOk(repo.deleteById());
-      chai.assert.isNotOk(repo.deleteById(12345));
-      chai.assert.isNotOk(repo.deleteById({}));
+      assert.isNotOk(repo.deleteById());
+      assert.isNotOk(repo.deleteById(12345));
+      assert.isNotOk(repo.deleteById({}));
     });
   });
 });

--- a/data/TaskRepository.test.js
+++ b/data/TaskRepository.test.js
@@ -18,10 +18,10 @@ describe('TaskRepository', () => {
     });
     it('should return an array of all tasks', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 4', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      repo.newTask({ title: 'Task 4', courseId: 1 });
       const result = repo.getAll();
       chai.assert.isArray(result);
       chai.assert.lengthOf(result, 4);
@@ -30,23 +30,23 @@ describe('TaskRepository', () => {
   describe('getById()', () => {
     it('should return the task with the given id', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      const taskToFind = repo.newTask({ title: 'Task 4', course: 'FOUND1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      const taskToFind = repo.newTask({ title: 'Task 4', courseId: 4 });
       const result = repo.getById(taskToFind.id);
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.title, 'Task 4');
-      chai.assert.strictEqual(result.course, 'FOUND1234');
+      chai.assert.strictEqual(result.courseId, 4);
     });
     it('should return falsy if a task with the given id does not exist', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
       chai.assert.isNotOk(repo.getById());
       chai.assert.isNotOk(repo.getById(10));
       chai.assert.isNotOk(repo.getById({}));
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
       chai.assert.isNotOk(repo.getById());
       chai.assert.isNotOk(repo.getById(9999));
       chai.assert.isNotOk(repo.getById({ id: 10 }));
@@ -55,127 +55,127 @@ describe('TaskRepository', () => {
   describe('update()', () => {
     it('should return the updated task', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      const updateId = repo.newTask({ title: 'UPDATE ME', course: 'UPDATE1234' }).id;
-      const result = repo.update({ id: updateId, title: 'new title', course: 'NEW1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      const updateId = repo.newTask({ title: 'UPDATE ME', courseId: 4 }).id;
+      const result = repo.update({ id: updateId, title: 'new title', courseId: 7 });
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.id, updateId);
     });
     it('should update any provided valid fields', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      const updateId = repo.newTask({ title: 'UPDATE ME', course: 'UPDATE1234' }).id;
-      const result = repo.update({ id: updateId, title: 'new title', course: 'NEW1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      const updateId = repo.newTask({ title: 'UPDATE ME', courseId: 4 }).id;
+      const result = repo.update({ id: updateId, title: 'new title', courseId: 5 });
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.id, updateId);
       chai.assert.strictEqual(result.title, 'new title');
-      chai.assert.strictEqual(result.course, 'NEW1234');
+      chai.assert.strictEqual(result.courseId, 5);
     });
     it('should return null if update is unsuccessful (no props object, no id field, task does not exist)', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 4', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      repo.newTask({ title: 'Task 4', courseId: 1 });
       chai.assert.isNotOk(repo.update());
       chai.assert.isNotOk(repo.update({}));
       chai.assert.isNotOk(repo.update({ id: 12345 }));
     });
   });
-  describe('getByCourse()', () => {
+  describe('getByCourseId()', () => {
     it('should return an array of all tasks matching the provided course', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 4', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 1', course: 'TEST5678' });
-      repo.newTask({ title: 'Task 2', course: 'TEST5678' });
-      repo.newTask({ title: 'Task 3', course: 'TEST5678' });
-      let result = repo.getByCourse('TEST1234');
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      repo.newTask({ title: 'Task 4', courseId: 1 });
+      repo.newTask({ title: 'Task 1', courseId: 5 });
+      repo.newTask({ title: 'Task 2', courseId: 5 });
+      repo.newTask({ title: 'Task 3', courseId: 5 });
+      let result = repo.getByCourseId(1);
       chai.assert.isArray(result);
       chai.assert.lengthOf(result, 4);
 
-      result = repo.getByCourse('TEST5678');
+      result = repo.getByCourseId(5);
       chai.assert.isArray(result);
       chai.assert.lengthOf(result, 3);
     });
     it('should return an empty array if no tasks match the course', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      chai.assert.isArray(repo.getByCourse());
-      chai.assert.isEmpty(repo.getByCourse());
-      chai.assert.isArray(repo.getByCourse('TEST1234'));
-      chai.assert.isEmpty(repo.getByCourse('TEST1234'));
+      chai.assert.isArray(repo.getByCourseId());
+      chai.assert.isEmpty(repo.getByCourseId());
+      chai.assert.isArray(repo.getByCourseId(1));
+      chai.assert.isEmpty(repo.getByCourseId(1));
 
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 4', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 1', course: 'TEST5678' });
-      repo.newTask({ title: 'Task 2', course: 'TEST5678' });
-      repo.newTask({ title: 'Task 3', course: 'TEST5678' });
-      chai.assert.isArray(repo.getByCourse());
-      chai.assert.isEmpty(repo.getByCourse());
-      chai.assert.isArray(repo.getByCourse('NONEXISTENTCOURSE'));
-      chai.assert.isEmpty(repo.getByCourse('NONEXISTENTCOURSE'));
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      repo.newTask({ title: 'Task 4', courseId: 1 });
+      repo.newTask({ title: 'Task 1', courseId: 5 });
+      repo.newTask({ title: 'Task 2', courseId: 5 });
+      repo.newTask({ title: 'Task 3', courseId: 5 });
+      chai.assert.isArray(repo.getByCourseId());
+      chai.assert.isEmpty(repo.getByCourseId());
+      chai.assert.isArray(repo.getByCourseId(777));
+      chai.assert.isEmpty(repo.getByCourseId(777));
     });
   });
   describe('newTask()', () => {
     it('should return the created task', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      const result = repo.newTask({ title: 'new task', course: 'TEST1234' });
+      const result = repo.newTask({ title: 'new task', courseId: 1 });
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.title, 'new task');
-      chai.assert.strictEqual(result.course, 'TEST1234');
+      chai.assert.strictEqual(result.courseId, 1);
     });
     it('should add the new task to the DAO', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      const newTask = repo.newTask({ title: 'new task', course: 'TEST1234' });
+      const newTask = repo.newTask({ title: 'new task', courseId: 1 });
       const result = repo.getById(newTask.id);
       chai.assert.isOk(result);
       chai.assert.strictEqual(result.title, 'new task');
-      chai.assert.strictEqual(result.course, 'TEST1234');
+      chai.assert.strictEqual(result.courseId, 1);
     });
     it('should return falsy if task creation is unsuccessful', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
       chai.assert.isNotOk(repo.newTask());
       chai.assert.isNotOk(repo.newTask({}));
       chai.assert.isNotOk(repo.newTask({ title: 'new task' }));
-      chai.assert.isNotOk(repo.newTask({ course: 'TEST1234' }));
+      chai.assert.isNotOk(repo.newTask({ courseId: 1 }));
     });
   });
   describe('deleteById()', () => {
     it('should return the deleted task', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      const taskToDelete = repo.newTask({ title: 'Task 4', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      const taskToDelete = repo.newTask({ title: 'Task 4', courseId: 1 });
       const result = repo.deleteById(taskToDelete.id);
       chai.assert.isOk(result);
       chai.assert.isObject(result);
       chai.assert.strictEqual(result.title, 'Task 4');
-      chai.assert.strictEqual(result.course, 'TEST1234');
+      chai.assert.strictEqual(result.courseId, 1);
     });
     it('should remove the task with the given id from the DAO', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
-      const taskToDelete = repo.newTask({ title: 'Task 4', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
+      const taskToDelete = repo.newTask({ title: 'Task 4', courseId: 1 });
       chai.assert.isOk(repo.getById(taskToDelete.id));
       const result = repo.deleteById(taskToDelete.id);
       chai.assert.isNotOk(repo.getById(taskToDelete.id));
     });
     it('should return falsy if task deletion is unsuccessful (task not found, id not provided)', () => {
       const repo = new TaskRepository(new TaskMemoryDAO());
-      repo.newTask({ title: 'Task 1', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 2', course: 'TEST1234' });
-      repo.newTask({ title: 'Task 3', course: 'TEST1234' });
+      repo.newTask({ title: 'Task 1', courseId: 1 });
+      repo.newTask({ title: 'Task 2', courseId: 1 });
+      repo.newTask({ title: 'Task 3', courseId: 1 });
       chai.assert.isNotOk(repo.deleteById());
       chai.assert.isNotOk(repo.deleteById(12345));
       chai.assert.isNotOk(repo.deleteById({}));

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -1,10 +1,16 @@
+const TaskMemoryDAO = require('./TaskMemoryDAO');
+const TaskRepository = require('./TaskRepository');
+const CourseMemoryDAO = require('./CourseMemoryDAO');
+const CourseRepository = require('./CourseRepository');
+
 const validateTaskTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
 const validateCourseId = (id) => (id && Number.isInteger(id));
 
 class UnitOfWork {
-  constructor(taskRepo, courseRepo) {
-    this.taskRepo = taskRepo;
-    this.courseRepo = courseRepo;
+  constructor(dbContext) {
+    this.dbContext = dbContext;
+    this.taskRepo = new TaskRepository(new TaskMemoryDAO());
+    this.courseRepo = new CourseRepository(new CourseMemoryDAO());
   }
 
   createTask(title, courseId) {

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -18,7 +18,7 @@ class UnitOfWork {
     }
     const course = this.courseRepo.getById(courseId);
     if (!course) {
-      throw new Error('A course with the given courseId does not exist');
+      throw new Error(`A course with id ${courseId} does not exist`);
     }
     return this.taskRepo.newTask({ title, courseId });
   }

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -3,8 +3,8 @@ const TaskRepository = require('./TaskRepository');
 const CourseMemoryDAO = require('./CourseMemoryDAO');
 const CourseRepository = require('./CourseRepository');
 
-const validateTaskTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
-const validateCourseId = (id) => (id && Number.isInteger(id));
+const validateTaskTitle = (title) => (title && typeof title === 'string');
+const validateCourseId = (id) => Number.isInteger(id);
 
 class UnitOfWork {
   constructor() {

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -1,0 +1,5 @@
+class UnitOfWork {
+
+}
+
+module.exports = UnitOfWork;

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -1,5 +1,6 @@
 const validateTaskTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
 const validateCourseId = (id) => (id && Number.isInteger(id));
+
 class UnitOfWork {
   constructor(taskRepo, courseRepo) {
     this.taskRepo = taskRepo;
@@ -7,9 +8,13 @@ class UnitOfWork {
   }
 
   createTask(title, courseId) {
-    if (!validateTaskTitle(title) || !validateCourseId(courseId)) throw new Error('A task must have a valid title and courseId');
+    if (!validateTaskTitle(title) || !validateCourseId(courseId)) {
+      throw new Error('A task must have a valid title and courseId');
+    }
     const course = this.courseRepo.getById(courseId);
-    if (!course) throw new Error('A course with the given courseId does not exist');
+    if (!course) {
+      throw new Error('A course with the given courseId does not exist');
+    }
     return this.taskRepo.newTask({ title, courseId });
   }
 }

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -7,8 +7,7 @@ const validateTaskTitle = (title) => (title && (typeof title === 'string' || tit
 const validateCourseId = (id) => (id && Number.isInteger(id));
 
 class UnitOfWork {
-  constructor(dbContext) {
-    this.dbContext = dbContext;
+  constructor() {
     this.taskRepo = new TaskRepository(new TaskMemoryDAO());
     this.courseRepo = new CourseRepository(new CourseMemoryDAO());
   }

--- a/data/UnitOfWork.js
+++ b/data/UnitOfWork.js
@@ -1,5 +1,17 @@
+const validateTaskTitle = (title) => (title && (typeof title === 'string' || title instanceof String));
+const validateCourseId = (id) => (id && Number.isInteger(id));
 class UnitOfWork {
+  constructor(taskRepo, courseRepo) {
+    this.taskRepo = taskRepo;
+    this.courseRepo = courseRepo;
+  }
 
+  createTask(title, courseId) {
+    if (!validateTaskTitle(title) || !validateCourseId(courseId)) throw new Error('A task must have a valid title and courseId');
+    const course = this.courseRepo.getById(courseId);
+    if (!course) throw new Error('A course with the given courseId does not exist');
+    return this.taskRepo.newTask({ title, courseId });
+  }
 }
 
 module.exports = UnitOfWork;

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -1,8 +1,3 @@
-/* eslint-disable prefer-destructuring */
-/* eslint-disable no-plusplus */
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
-
 const chai = require('chai');
 
 const expect = chai.expect;

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -1,31 +1,30 @@
+/* eslint-disable prefer-destructuring */
 /* eslint-disable no-plusplus */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 
 const chai = require('chai');
 
-const should = chai.should();
+const expect = chai.expect;
 const UnitOfWork = require('./UnitOfWork');
 const InMemoryDataStore = require('./InMemoryDataStore');
 const Task = require('./Task');
-const TaskMemoryDAO = require('./TaskMemoryDAO');
 const TaskRepository = require('./TaskRepository');
-const CourseMemoryDAO = require('./CourseMemoryDAO');
 const CourseRepository = require('./CourseRepository');
 
 describe('UnitOfWork', () => {
   describe('constructor()', () => {
     it('Should have acces to a TaskRepository and a CourseRepository', () => {
-      const uow = new UnitOfWork();
-      chai.expect(uow.taskRepo).to.be.an.instanceOf(TaskRepository);
-      chai.expect(uow.courseRepo).to.be.an.instanceOf(CourseRepository);
+      const unitOfWork = new UnitOfWork();
+      expect(unitOfWork.taskRepo).to.be.an.instanceOf(TaskRepository);
+      expect(unitOfWork.courseRepo).to.be.an.instanceOf(CourseRepository);
     });
   });
 
   describe('createTask()', () => {
-    let uow;
+    let unitOfWork;
     beforeEach(() => {
-      uow = new UnitOfWork();
+      unitOfWork = new UnitOfWork();
       InMemoryDataStore.clear();
     });
 
@@ -34,26 +33,26 @@ describe('UnitOfWork', () => {
     });
 
     it('should create and return a task with a valid title and course id', () => {
-      const courseId = uow.courseRepo.newCourse('My Course').id;
-      const result = uow.createTask('My Task', courseId);
-      chai.expect(result).to.be.an.instanceOf(Task);
-      chai.expect(result.title).to.equal('My Task');
-      chai.expect(result.courseId).to.equal(courseId);
+      const courseId = unitOfWork.courseRepo.newCourse('My Course').id;
+      const result = unitOfWork.createTask('My Task', courseId);
+      expect(result).to.be.an.instanceOf(Task);
+      expect(result.title).to.equal('My Task');
+      expect(result.courseId).to.equal(courseId);
     });
 
     it('should not allow a task to be created if the given courseId does not exist', () => {
-      chai.expect(() => uow.createTask('My Task', 5)).to.throw('A course with the given courseId does not exist');
-      uow.courseRepo.newCourse('My Course 1');
-      uow.courseRepo.newCourse('My Course 2');
-      uow.courseRepo.newCourse('My Course 3');
-      chai.expect(() => uow.createTask('My Task', -1)).to.throw('A course with the given courseId does not exist');
+      expect(() => unitOfWork.createTask('My Task', 5)).to.throw('A course with the given courseId does not exist');
+      unitOfWork.courseRepo.newCourse('My Course 1');
+      unitOfWork.courseRepo.newCourse('My Course 2');
+      unitOfWork.courseRepo.newCourse('My Course 3');
+      expect(() => unitOfWork.createTask('My Task', -1)).to.throw('A course with the given courseId does not exist');
     });
 
     it('should not allow a task to be created with invalid input', () => {
-      chai.expect(() => uow.createTask()).to.throw('A task must have a valid title and courseId');
-      chai.expect(() => uow.createTask('My Task')).to.throw('A task must have a valid title and courseId');
-      chai.expect(() => uow.createTask(1234)).to.throw('A task must have a valid title and courseId');
-      chai.expect(() => uow.createTask(1234, {})).to.throw('A task must have a valid title and courseId');
+      expect(() => unitOfWork.createTask()).to.throw('A task must have a valid title and courseId');
+      expect(() => unitOfWork.createTask('My Task')).to.throw('A task must have a valid title and courseId');
+      expect(() => unitOfWork.createTask(1234)).to.throw('A task must have a valid title and courseId');
+      expect(() => unitOfWork.createTask(1234, {})).to.throw('A task must have a valid title and courseId');
     });
   });
 });

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -22,6 +22,7 @@ describe('UnitOfWork', () => {
       chai.expect(uow.courseRepo).to.be.an.instanceOf(CourseRepository);
     });
   });
+
   describe('createTask()', () => {
     let uow;
     beforeEach(() => {
@@ -29,6 +30,7 @@ describe('UnitOfWork', () => {
       const courseRepo = new CourseRepository(new CourseMemoryDAO());
       uow = new UnitOfWork(taskRepo, courseRepo);
     });
+
     it('should create and return a task with a valid title and course id', () => {
       const courseId = uow.courseRepo.newCourse('My Course').id;
       const result = uow.createTask('My Task', courseId);
@@ -36,6 +38,7 @@ describe('UnitOfWork', () => {
       chai.expect(result.title).to.equal('My Task');
       chai.expect(result.courseId).to.equal(courseId);
     });
+
     it('should not allow a task to be created if the given courseId does not exist', () => {
       chai.expect(() => uow.createTask('My Task', 5)).to.throw('A course with the given courseId does not exist');
       uow.courseRepo.newCourse('My Course 1');
@@ -43,6 +46,7 @@ describe('UnitOfWork', () => {
       uow.courseRepo.newCourse('My Course 3');
       chai.expect(() => uow.createTask('My Task', -1)).to.throw('A course with the given courseId does not exist');
     });
+
     it('should not allow a task to be created with invalid input', () => {
       chai.expect(() => uow.createTask()).to.throw('A task must have a valid title and courseId');
       chai.expect(() => uow.createTask('My Task')).to.throw('A task must have a valid title and courseId');

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+
+const chai = require('chai');
+
+const should = chai.should();
+const UnitOfWork = require('./UnitOfWork');
+const Task = require('./Task');
+const TaskMemoryDAO = require('./TaskMemoryDAO');
+const TaskRepository = require('./TaskRepository');
+const CourseMemoryDAO = require('./CourseMemoryDAO');
+const CourseRepository = require('./CourseRepository');
+
+describe('UnitOfWork', () => {
+  describe('constructor()', () => {
+    it('Should accept and set a TaskRepository and a CourseRepository', () => {
+      const taskRepo = new TaskRepository(new TaskMemoryDAO());
+      const courseRepo = new CourseRepository(new CourseMemoryDAO());
+      const uow = new UnitOfWork(taskRepo, courseRepo);
+      chai.expect(uow.taskRepo).to.be.an.instanceOf(TaskRepository);
+      chai.expect(uow.courseRepo).to.be.an.instanceOf(CourseRepository);
+    });
+  });
+  describe('createTask()', () => {
+    let uow;
+    beforeEach(() => {
+      const taskRepo = new TaskRepository(new TaskMemoryDAO());
+      const courseRepo = new CourseRepository(new CourseMemoryDAO());
+      uow = new UnitOfWork(taskRepo, courseRepo);
+    });
+    it('should create and return a task with a valid title and course id', () => {
+      const courseId = uow.courseRepo.newCourse('My Course').id;
+      const result = uow.createTask('My Task', courseId);
+      chai.expect(result).to.be.an.instanceOf(Task);
+      chai.expect(result.title).to.equal('My Task');
+      chai.expect(result.courseId).to.equal(courseId);
+    });
+    it('should not allow a task to be created if the given courseId does not exist', () => {
+      chai.expect(() => uow.createTask('My Task', 5)).to.throw('A course with the given courseId does not exist');
+      uow.courseRepo.newCourse('My Course 1');
+      uow.courseRepo.newCourse('My Course 2');
+      uow.courseRepo.newCourse('My Course 3');
+      chai.expect(() => uow.createTask('My Task', -1)).to.throw('A course with the given courseId does not exist');
+    });
+    it('should not allow a task to be created with invalid input', () => {
+      chai.expect(() => uow.createTask()).to.throw('A task must have a valid title and courseId');
+      chai.expect(() => uow.createTask('My Task')).to.throw('A task must have a valid title and courseId');
+      chai.expect(() => uow.createTask(1234)).to.throw('A task must have a valid title and courseId');
+      chai.expect(() => uow.createTask(1234, {})).to.throw('A task must have a valid title and courseId');
+    });
+  });
+});

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -36,11 +36,11 @@ describe('UnitOfWork', () => {
     });
 
     it('should not allow a task to be created if the given courseId does not exist', () => {
-      expect(() => unitOfWork.createTask('My Task', 5)).to.throw('A course with the given courseId does not exist');
+      expect(() => unitOfWork.createTask('My Task', 5)).to.throw('A course with id 5 does not exist');
       unitOfWork.courseRepo.newCourse('My Course 1');
       unitOfWork.courseRepo.newCourse('My Course 2');
       unitOfWork.courseRepo.newCourse('My Course 3');
-      expect(() => unitOfWork.createTask('My Task', -1)).to.throw('A course with the given courseId does not exist');
+      expect(() => unitOfWork.createTask('My Task', -1)).to.throw('A course with id -1 does not exist');
     });
 
     it('should not allow a task to be created with invalid input', () => {

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -14,10 +14,8 @@ const CourseRepository = require('./CourseRepository');
 
 describe('UnitOfWork', () => {
   describe('constructor()', () => {
-    it('Should accept and set a TaskRepository and a CourseRepository', () => {
-      const taskRepo = new TaskRepository(new TaskMemoryDAO());
-      const courseRepo = new CourseRepository(new CourseMemoryDAO());
-      const uow = new UnitOfWork(taskRepo, courseRepo);
+    it('Should have acces to a TaskRepository and a CourseRepository', () => {
+      const uow = new UnitOfWork();
       chai.expect(uow.taskRepo).to.be.an.instanceOf(TaskRepository);
       chai.expect(uow.courseRepo).to.be.an.instanceOf(CourseRepository);
     });
@@ -26,9 +24,7 @@ describe('UnitOfWork', () => {
   describe('createTask()', () => {
     let uow;
     beforeEach(() => {
-      const taskRepo = new TaskRepository(new TaskMemoryDAO());
-      const courseRepo = new CourseRepository(new CourseMemoryDAO());
-      uow = new UnitOfWork(taskRepo, courseRepo);
+      uow = new UnitOfWork();
     });
 
     it('should create and return a task with a valid title and course id', () => {

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -6,6 +6,7 @@ const chai = require('chai');
 
 const should = chai.should();
 const UnitOfWork = require('./UnitOfWork');
+const InMemoryDataStore = require('./InMemoryDataStore');
 const Task = require('./Task');
 const TaskMemoryDAO = require('./TaskMemoryDAO');
 const TaskRepository = require('./TaskRepository');
@@ -25,6 +26,11 @@ describe('UnitOfWork', () => {
     let uow;
     beforeEach(() => {
       uow = new UnitOfWork();
+      InMemoryDataStore.clear();
+    });
+
+    afterEach(() => {
+      InMemoryDataStore.clear();
     });
 
     it('should create and return a task with a valid title and course id', () => {

--- a/data/UnitOfWork.test.js
+++ b/data/UnitOfWork.test.js
@@ -20,7 +20,6 @@ describe('UnitOfWork', () => {
     let unitOfWork;
     beforeEach(() => {
       unitOfWork = new UnitOfWork();
-      InMemoryDataStore.clear();
     });
 
     afterEach(() => {

--- a/dev/seed.js
+++ b/dev/seed.js
@@ -1,17 +1,17 @@
 const UnitOfWork = require('../data/UnitOfWork');
 
-const uow = new UnitOfWork();
+const unitOfWork = new UnitOfWork();
 
 const seed = (taskCount, courseCount) => {
   const numberOfTasks = taskCount || 10;
   const numberOfCourses = courseCount || 4;
   const courseIds = [];
   for (let i = 1; i <= numberOfCourses; i += 1) {
-    courseIds.push(uow.courseRepo.newCourse(`Course ${i}`).id);
+    courseIds.push(unitOfWork.courseRepo.newCourse(`Course ${i}`).id);
   }
   let courseIdsIndex = 0;
   for (let taskSuffix = 1; taskSuffix <= numberOfTasks; taskSuffix += 1) {
-    uow.createTask(`Test Task ${taskSuffix}`, courseIds[courseIdsIndex]);
+    unitOfWork.createTask(`Test Task ${taskSuffix}`, courseIds[courseIdsIndex]);
     courseIdsIndex += 1;
     if (courseIdsIndex > courseIds.length - 1) {
       courseIdsIndex = 0;

--- a/dev/seed.js
+++ b/dev/seed.js
@@ -1,12 +1,12 @@
 const seed = (repo, taskCount, courseCount) => {
   const numberOfTasks = taskCount || 10;
   const numberOfCourses = courseCount || 4;
-  let courseSuffix = 1;
+  let courseId = 1;
   for (let taskSuffix = 1; taskSuffix <= numberOfTasks; taskSuffix += 1) {
-    repo.newTask({ title: `Test Task ${taskSuffix}`, course: `TEST COURSE ${courseSuffix}` });
-    courseSuffix += 1;
-    if (courseSuffix > numberOfCourses) {
-      courseSuffix = 1;
+    repo.newTask({ title: `Test Task ${taskSuffix}`, courseId });
+    courseId += 1;
+    if (courseId > numberOfCourses) {
+      courseId = 1;
     }
   }
 };

--- a/dev/seed.js
+++ b/dev/seed.js
@@ -1,12 +1,20 @@
-const seed = (repo, taskCount, courseCount) => {
+const UnitOfWork = require('../data/UnitOfWork');
+
+const uow = new UnitOfWork();
+
+const seed = (taskCount, courseCount) => {
   const numberOfTasks = taskCount || 10;
   const numberOfCourses = courseCount || 4;
-  let courseId = 1;
+  const courseIds = [];
+  for (let i = 1; i <= numberOfCourses; i += 1) {
+    courseIds.push(uow.courseRepo.newCourse(`Course ${i}`).id);
+  }
+  let courseIdsIndex = 0;
   for (let taskSuffix = 1; taskSuffix <= numberOfTasks; taskSuffix += 1) {
-    repo.newTask({ title: `Test Task ${taskSuffix}`, courseId });
-    courseId += 1;
-    if (courseId > numberOfCourses) {
-      courseId = 1;
+    uow.createTask(`Test Task ${taskSuffix}`, courseIds[courseIdsIndex]);
+    courseIdsIndex += 1;
+    if (courseIdsIndex > courseIds.length - 1) {
+      courseIdsIndex = 0;
     }
   }
 };

--- a/dev/seed.test.js
+++ b/dev/seed.test.js
@@ -5,8 +5,7 @@
 const chai = require('chai');
 
 const should = chai.should();
-const TaskMemoryDAO = require('../data/TaskMemoryDAO');
-const TaskRepository = require('../data/TaskRepository');
+const InMemoryDataStore = require('../data/InMemoryDataStore');
 const seed = require('./seed');
 
 const getUniqueCourses = (tasks) => tasks.reduce((courseList, task) => {
@@ -16,42 +15,35 @@ const getUniqueCourses = (tasks) => tasks.reduce((courseList, task) => {
 
 describe('Seed In Memory Database', () => {
   describe('seed()', () => {
-    it('should seed the repository with 10 tasks by default', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
-      seed(repo);
-      chai.assert.isNotNull(repo.getAll());
-      chai.assert.lengthOf(repo.getAll(), 10);
+    afterEach(() => {
+      InMemoryDataStore.clear();
+    });
+    it('should seed the in memory datastore with 10 tasks by default', () => {
+      seed();
+      chai.assert.isNotNull(InMemoryDataStore.tasks);
+      chai.assert.lengthOf(InMemoryDataStore.tasks, 10);
     });
     it('should take a number as an argument to determine the number of tasks to generate', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
-      seed(repo, 100);
-      chai.assert.isNotNull(repo.getAll());
-      chai.assert.lengthOf(repo.getAll(), 100);
+      seed(100);
+      chai.assert.isNotNull(InMemoryDataStore.tasks);
+      chai.assert.lengthOf(InMemoryDataStore.tasks, 100);
     });
     it('should support an argument to determine the number of unique course names to generate tasks under', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
-      seed(repo, 100, 5);
-      const tasks = repo.getAll();
-      chai.assert.isNotNull(tasks);
-
-      const uniqueCourses = getUniqueCourses(tasks);
+      seed(100, 5);
+      chai.assert.isNotNull(InMemoryDataStore.tasks);
+      const uniqueCourses = getUniqueCourses(InMemoryDataStore.tasks);
       chai.assert.lengthOf(uniqueCourses, 5);
     });
     it('should default to generating tasks under 4 unique course names', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
-      seed(repo, 100);
-      const tasks = repo.getAll();
-      chai.assert.isNotNull(tasks);
-
-      const uniqueCourses = getUniqueCourses(tasks);
+      seed(100);
+      chai.assert.isNotNull(InMemoryDataStore.tasks);
+      const uniqueCourses = getUniqueCourses(InMemoryDataStore.tasks);
       chai.assert.lengthOf(uniqueCourses, 4);
     });
     it('should generate the same number of unique courses as the number of tasks when numberOfCourses > numberOfTasks', () => {
-      const repo = new TaskRepository(new TaskMemoryDAO());
-      seed(repo, 5, 6);
-      const tasks = repo.getAll();
-      chai.assert.isNotNull(tasks);
-      const uniqueCourses = getUniqueCourses(tasks);
+      seed(5, 6);
+      chai.assert.isNotNull(InMemoryDataStore.tasks);
+      const uniqueCourses = getUniqueCourses(InMemoryDataStore.tasks);
       chai.assert.lengthOf(uniqueCourses, 5);
     });
   });

--- a/dev/seed.test.js
+++ b/dev/seed.test.js
@@ -10,7 +10,7 @@ const TaskRepository = require('../data/TaskRepository');
 const seed = require('./seed');
 
 const getUniqueCourses = (tasks) => tasks.reduce((courseList, task) => {
-  if (!courseList.includes(task.course)) courseList.push(task.course);
+  if (!courseList.includes(task.courseId)) courseList.push(task.courseId);
   return courseList;
 }, []);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -513,7 +512,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -523,20 +521,17 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -547,7 +542,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -689,8 +683,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -817,8 +810,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2028,8 +2020,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -3786,14 +3777,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.14.1",
@@ -3934,8 +3923,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -4630,8 +4618,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
@@ -4661,7 +4648,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4671,14 +4657,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -4688,7 +4672,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -4696,20 +4679,17 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -4720,7 +4700,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -4762,8 +4741,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -4775,7 +4753,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
       "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
-      "dev": true,
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -4793,20 +4770,17 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -4815,14 +4789,12 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -4831,7 +4803,6 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
           "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -4840,7 +4811,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -4848,20 +4818,17 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -4872,7 +4839,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -4881,7 +4847,6 @@
           "version": "16.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
           "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha ./**/*.test.js",
-    "dev": "NODE_ENV=development nodemon server.js",
+    "dev": "NODE_ENV=development node server.js",
     "start": "nodemon server.js"
   },
   "author": "",

--- a/routes/course.js
+++ b/routes/course.js
@@ -6,9 +6,9 @@ const router = express.Router();
 router.use(express.json());
 
 router.get('/', courseController.getAll);
-router.get('/:id', courseController.getByID);
+router.get('/:id', courseController.getById);
 router.post('/', courseController.create);
-router.post('/:id', courseController.updateByID);
-router.delete('/:id', courseController.deleteByID);
+router.post('/:id', courseController.updateById);
+router.delete('/:id', courseController.deleteById);
 
 module.exports = router;

--- a/routes/course.js
+++ b/routes/course.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const courseController = require('../controllers/courseController');
+
+const router = express.Router();
+
+router.use(express.json());
+
+router.get('/', courseController.getAll);
+router.get('/:id', courseController.getByID);
+router.post('/', courseController.create);
+router.post('/:id', courseController.updateByID);
+router.delete('/:id', courseController.deleteByID);
+
+module.exports = router;

--- a/routes/task.js
+++ b/routes/task.js
@@ -6,9 +6,9 @@ const router = express.Router();
 router.use(express.json());
 
 router.get('/', taskController.getAll);
-router.get('/:id', taskController.getByID);
+router.get('/:id', taskController.getById);
 router.post('/', taskController.create);
-router.post('/:id', taskController.updateByID);
-router.delete('/:id', taskController.deleteByID);
+router.post('/:id', taskController.updateById);
+router.delete('/:id', taskController.deleteById);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const taskRouter = require('./routes/task');
+const courseRouter = require('./routes/course');
 
 const app = express();
 
 app.use('/api/task', taskRouter);
+app.use('/api/course', courseRouter);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/server.js
+++ b/server.js
@@ -1,11 +1,19 @@
 const express = require('express');
+// eslint-disable-next-line prefer-destructuring
+const argv = require('yargs').argv;
 const taskRouter = require('./routes/task');
 const courseRouter = require('./routes/course');
+const seed = require('./dev/seed');
 
 const app = express();
 
 app.use('/api/task', taskRouter);
 app.use('/api/course', courseRouter);
+
+if (process.env.NODE_ENV === 'development' && argv.seed) {
+  console.log('seeding database...');
+  seed(argv.taskCount, argv.courseCount);
+}
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {


### PR DESCRIPTION
- Added course object
- Changed tasks to refer to courseId instead of have a course attribute
- Implemented Unit of Work pattern to handle repositories
- controllers now use UnitOfWork instead of repositories
- Seeding algorithm can now be run in development mode with the seed flag (default taskCount is 10, default courseCount is 4):
`npm run dev -- --seed --taskCount={Integer} --courseCount={Integer}`